### PR TITLE
Add extra methods for TransactionComputer

### DIFF
--- a/multiversx_sdk/core/constants.py
+++ b/multiversx_sdk/core/constants.py
@@ -15,6 +15,7 @@ DELEGATION_MANAGER_SC_ADDRESS = "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqq
 DEFAULT_HRP = "erd"
 CONTRACT_DEPLOY_ADDRESS = "erd1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gq4hu"
 TRANSACTION_OPTIONS_TX_GUARDED = 0b0010
+TRANSACTION_OPTIONS_TX_HASH_SIGN = 0b0001
 
 DIGEST_SIZE = 32
 

--- a/multiversx_sdk/core/transaction.py
+++ b/multiversx_sdk/core/transaction.py
@@ -7,6 +7,8 @@ from typing import Any, Dict, Optional, Protocol
 from multiversx_sdk.core.constants import (DEFAULT_HRP, DIGEST_SIZE,
                                            TRANSACTION_MIN_GAS_PRICE,
                                            TRANSACTION_OPTIONS_DEFAULT,
+                                           TRANSACTION_OPTIONS_TX_GUARDED,
+                                           TRANSACTION_OPTIONS_TX_HASH_SIGN,
                                            TRANSACTION_VERSION_DEFAULT)
 from multiversx_sdk.core.errors import NotEnoughGasError
 from multiversx_sdk.core.interfaces import INetworkConfig, ITransaction
@@ -91,6 +93,17 @@ class TransactionComputer:
         serialized_tx = proto.serialize_transaction(transaction)
         tx_hash = blake2b(serialized_tx, digest_size=DIGEST_SIZE).hexdigest()
         return bytes.fromhex(tx_hash)
+
+    def has_options_set_for_guarded_transaction(self, transaction: ITransaction) -> bool:
+        return (transaction.options & TRANSACTION_OPTIONS_TX_GUARDED) == TRANSACTION_OPTIONS_TX_GUARDED
+
+    def has_options_set_for_hash_signing(self, transaction: ITransaction) -> bool:
+        return (transaction.options & TRANSACTION_OPTIONS_TX_HASH_SIGN) == TRANSACTION_OPTIONS_TX_HASH_SIGN
+
+    def apply_guardian(self, transaction: ITransaction, guardian: str) -> None:
+        transaction.version = 2
+        transaction.options = transaction.options | TRANSACTION_OPTIONS_TX_GUARDED
+        transaction.guardian = guardian
 
     def _to_dictionary(self, transaction: ITransaction) -> Dict[str, Any]:
         dictionary: Dict[str, Any] = OrderedDict()

--- a/multiversx_sdk/core/transaction_test.py
+++ b/multiversx_sdk/core/transaction_test.py
@@ -191,3 +191,34 @@ class TestTransaction:
 
         tx_hash = self.transaction_computer.compute_transaction_hash(transaction)
         assert tx_hash.hex() == "242022e9dcfa0ee1d8199b0043314dbda8601619f70069ebc441b9f03349a35c"
+
+    def test_tx_computer_has_options_set(self):
+        tx = Transaction(
+            sender="erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th",
+            receiver="erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th",
+            gas_limit=50000,
+            chain_id="D",
+            options=3
+        )
+
+        assert self.transaction_computer.has_options_set_for_guarded_transaction(tx)
+        assert self.transaction_computer.has_options_set_for_hash_signing(tx)
+
+    def test_tx_computer_apply_guardian(self):
+        tx = Transaction(
+            sender="erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th",
+            receiver="erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th",
+            gas_limit=200000,
+            chain_id="D",
+            version=1,
+            options=1
+        )
+
+        self.transaction_computer.apply_guardian(
+            transaction=tx,
+            guardian="erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx"
+        )
+
+        assert tx.version == 2
+        assert tx.options == 3
+        assert tx.guardian == "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx"


### PR DESCRIPTION
Added some extra methods for `TransactionComputer` according to the [sdk-specs](https://github.com/multiversx/mx-sdk-specs/blob/main/sdk-core/transaction.md#transactioncomputer).