### PR TITLE
Additional fields on "AccountOnNetwork"

### DIFF
--- a/multiversx_sdk/network_providers/accounts.py
+++ b/multiversx_sdk/network_providers/accounts.py
@@ -1,3 +1,4 @@
+import base64
 from typing import Any, Dict
 
 from multiversx_sdk.core.address import Address
@@ -8,35 +9,47 @@ from multiversx_sdk.network_providers.resources import EmptyAddress
 class AccountOnNetwork:
     def __init__(self):
         self.address: IAddress = EmptyAddress()
+        self.owner_address = EmptyAddress()
         self.nonce: int = 0
         self.balance: int = 0
-        self.code: bytes = b''
-        self.username: str = ''
-        self.code_hash: str = ''
+        self.developer_reward = 0
+        self.code: bytes = b""
+        self.username: str = ""
+        self.code_hash: str = ""
+        self.root_hash: str = ""
 
     @staticmethod
-    def from_http_response(payload: Dict[str, Any]) -> 'AccountOnNetwork':
+    def from_http_response(payload: Dict[str, Any]) -> "AccountOnNetwork":
         result = AccountOnNetwork()
 
-        address = payload.get('address', '')
-        result.address = Address.new_from_bech32(address) if address else EmptyAddress()
+        address = payload.get("address", "")
+        owner_address = payload.get("ownerAddress", "")
 
-        result.nonce = payload.get('nonce', 0)
-        result.balance = int(payload.get('balance', 0))
-        result.code = bytes.fromhex(payload.get('code', ''))
-        result.username = payload.get('username', '')
-        result.code_hash = payload.get('codeHash', '')
+        result.address = Address.new_from_bech32(address) if address else EmptyAddress()
+        result.owner_address = Address.new_from_bech32(owner_address) if owner_address else EmptyAddress()
+
+        result.nonce = payload.get("nonce", 0)
+        result.balance = int(payload.get("balance", 0))
+        result.developer_reward = int(payload.get("developerReward", 0))
+
+        result.code = bytes.fromhex(payload.get("code", ""))
+        result.username = payload.get("username", "")
+        result.code_hash = base64.b64decode(payload.get("codeHash", "") or "").hex()
+        result.root_hash = base64.b64decode(payload.get("rootHash", "") or "").hex()
 
         return result
 
     def to_dictionary(self) -> Dict[str, Any]:
         return {
             "address": self.address.to_bech32(),
+            "ownerAddress": self.owner_address.to_bech32(),
             "nonce": self.nonce,
             "balance": self.balance,
+            "developerReward": self.developer_reward,
             "code": self.code.hex(),
             "username": self.username,
-            "codeHash": self.code_hash
+            "codeHash": self.code_hash,
+            "rootHash": self.root_hash
         }
 
 
@@ -47,10 +60,10 @@ class GuardianData:
         self.pending_guardian: Guardian = Guardian()
 
     @staticmethod
-    def from_http_response(response: Dict[str, Any]) -> 'GuardianData':
+    def from_http_response(response: Dict[str, Any]) -> "GuardianData":
         result = GuardianData()
 
-        result.guarded = response.get('guarded', False)
+        result.guarded = response.get("guarded", False)
 
         if response.get("activeGuardian", None):
             result.active_guardian = Guardian.from_http_response(response["activeGuardian"])
@@ -73,11 +86,11 @@ class Guardian:
         self.service_uid: str = ""
 
     @staticmethod
-    def from_http_response(response: Dict[str, Any]) -> 'Guardian':
+    def from_http_response(response: Dict[str, Any]) -> "Guardian":
         result = Guardian()
 
-        result.activation_epoch = int(response.get('activationEpoch', 0))
-        result.address = Address.new_from_bech32(response.get('address', ''))
-        result.service_uid = response.get('serviceUID', '')
+        result.activation_epoch = int(response.get("activationEpoch", 0))
+        result.address = Address.new_from_bech32(response.get("address", ""))
+        result.service_uid = response.get("serviceUID", "")
 
         return result

--- a/multiversx_sdk/network_providers/accounts.py
+++ b/multiversx_sdk/network_providers/accounts.py
@@ -1,4 +1,3 @@
-import base64
 from typing import Any, Dict
 
 from multiversx_sdk.core.address import Address
@@ -34,8 +33,8 @@ class AccountOnNetwork:
 
         result.code = bytes.fromhex(payload.get("code", ""))
         result.username = payload.get("username", "")
-        result.code_hash = base64.b64decode(payload.get("codeHash", "") or "").hex()
-        result.root_hash = base64.b64decode(payload.get("rootHash", "") or "").hex()
+        result.code_hash = payload.get("codeHash", "")
+        result.root_hash = payload.get("rootHash", "")
 
         return result
 

--- a/multiversx_sdk/network_providers/api_network_provider_test.py
+++ b/multiversx_sdk/network_providers/api_network_provider_test.py
@@ -58,6 +58,8 @@ class TestApi:
 
         assert result.address.to_bech32() == 'erd1487vz5m4zpxjyqw4flwa3xhnkzg4yrr3mkzf5sf0zgt94hjprc8qazcccl'
         assert result.username == ''
+        assert len(result.code_hash) == 0
+        assert len(result.root_hash) == 64
 
     def test_get_generic_with_bad_address(self):
         with pytest.raises(GenericError, match='a bech32 address is expected'):

--- a/multiversx_sdk/network_providers/api_network_provider_test.py
+++ b/multiversx_sdk/network_providers/api_network_provider_test.py
@@ -1,3 +1,5 @@
+import base64
+
 import pytest
 
 from multiversx_sdk.core.address import Address
@@ -56,10 +58,18 @@ class TestApi:
         address = Address.new_from_bech32('erd1487vz5m4zpxjyqw4flwa3xhnkzg4yrr3mkzf5sf0zgt94hjprc8qazcccl')
         result = self.api.get_account(address)
 
-        assert result.address.to_bech32() == 'erd1487vz5m4zpxjyqw4flwa3xhnkzg4yrr3mkzf5sf0zgt94hjprc8qazcccl'
+        assert result.address.to_bech32() == address.to_bech32()
         assert result.username == ''
         assert len(result.code_hash) == 0
-        assert len(result.root_hash) == 64
+        assert len(base64.b64decode(result.root_hash)) == 32
+
+        address = Address.new_from_bech32('erd1qqqqqqqqqqqqqpgqws44xjx2t056nn79fn29q0rjwfrd3m43396ql35kxy')
+        result = self.api.get_account(address)
+
+        assert result.address.to_bech32() == address.to_bech32()
+        assert result.username == ''
+        assert len(base64.b64decode(result.code_hash)) == 32
+        assert len(base64.b64decode(result.root_hash)) == 32
 
     def test_get_generic_with_bad_address(self):
         with pytest.raises(GenericError, match='a bech32 address is expected'):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "multiversx-sdk"
-version = "0.9.1"
+version = "0.9.2"
 authors = [
   { name="MultiversX" },
 ]


### PR DESCRIPTION
See:
 - https://api.multiversx.com/accounts/erd1qqqqqqqqqqqqqpgqvc7gdl0p4s97guh498wgz75k8sav6sjfjlwqh679jy
 - https://gateway.multiversx.com/address/erd1qqqqqqqqqqqqqpgqvc7gdl0p4s97guh498wgz75k8sav6sjfjlwqh679jy

`code_hash` and `root_hash` are base64-encoded, which is somehow unfortunate. Their encoding wasn't changed to hex, in order to avoid a breaking change.