### PR TITLE
ABI/codecs implementation (part 1)

### DIFF
--- a/multiversx_sdk/abi/codec.py
+++ b/multiversx_sdk/abi/codec.py
@@ -1,0 +1,34 @@
+
+import io
+from typing import Any
+
+from multiversx_sdk.abi.interface import SingleValue
+
+
+class Codec:
+    def __init__(self) -> None:
+        pass
+
+    def encode_nested(self, value: SingleValue) -> bytes:
+        buffer = io.BytesIO()
+        value.encode_nested(buffer)
+        return buffer.getvalue()
+
+    def encode_top_level(self, value: Any) -> bytes:
+        buffer = io.BytesIO()
+        value.encode_top_level(buffer)
+        return buffer.getvalue()
+
+    def decode_nested(self, data: bytes, value: Any) -> None:
+        reader = io.BytesIO(data)
+
+        try:
+            value.decode_nested(reader)
+        except ValueError as e:
+            raise ValueError(f"cannot decode (nested) {type(value)}, because of: {e}")
+
+    def decode_top_level(self, data: bytes, value: Any) -> None:
+        try:
+            value.decode_top_level(data)
+        except ValueError as e:
+            raise ValueError(f"cannot decode (top-level) {type(value).__name__}, because of: {e}")

--- a/multiversx_sdk/abi/serializer.py
+++ b/multiversx_sdk/abi/serializer.py
@@ -1,0 +1,116 @@
+from typing import Any, List, Sequence
+
+from multiversx_sdk.abi.codec import Codec
+from multiversx_sdk.abi.parts import PartsHolder
+from multiversx_sdk.abi.values_multi import *
+
+
+class Serializer:
+    """
+    The serializer follows the rules of the MultiversX Serialization format:
+    https://docs.multiversx.com/developers/data/serialization-overview
+    """
+
+    def __init__(self, parts_separator: str):
+        if not parts_separator:
+            raise ValueError("cannot create serializer: parts separator must not be empty")
+
+        self.parts_separator = parts_separator
+        self.codec = Codec()
+
+    def serialize(self, input_values: Sequence[Any]) -> str:
+        parts = self.serialize_to_parts(input_values)
+        return self._encode_parts(parts)
+
+    def serialize_to_parts(self, input_values: Sequence[Any]) -> List[bytes]:
+        parts_holder = PartsHolder([])
+        self._do_serialize(parts_holder, input_values)
+        return parts_holder.get_parts()
+
+    def _do_serialize(self, parts_holder: PartsHolder, input_values: Sequence[Any]):
+        for i, value in enumerate(input_values):
+            if value is None:
+                raise ValueError("cannot serialize nil value")
+
+            if isinstance(value, OptionalValue):
+                if i != len(input_values) - 1:
+                    # Usage of multiple optional values is not recommended:
+                    # https://docs.multiversx.com/developers/data/multi-values
+                    # Thus, here, we disallow them.
+                    raise ValueError("an optional value must be last among input values")
+
+                if value.value is not None:
+                    self._do_serialize(parts_holder, [value.value])
+            elif isinstance(value, MultiValue):
+                self._do_serialize(parts_holder, value.items)
+            elif isinstance(value, VariadicValues):
+                if i != len(input_values) - 1:
+                    raise ValueError("variadic values must be last among input values")
+
+                self._do_serialize(parts_holder, value.items)
+            else:
+                parts_holder.append_empty_part()
+                self._serialize_single_value(parts_holder, value)
+
+    def _serialize_single_value(self, parts_holder: PartsHolder, value: Any):
+        data = self.codec.encode_top_level(value)
+        parts_holder.append_to_last_part(data)
+
+    def deserialize(self, data: str, output_values: Sequence[Any]):
+        parts = self._decode_into_parts(data)
+        self.deserialize_parts(parts, output_values)
+
+    def deserialize_parts(self, parts: Sequence[bytes], output_values: Sequence[Any]):
+        parts_holder = PartsHolder(parts)
+        self._do_deserialize(parts_holder, output_values)
+
+    def _do_deserialize(self, parts_holder: PartsHolder, output_values: Sequence[Any]):
+        for i, value in enumerate(output_values):
+            if value is None:
+                raise ValueError("cannot deserialize into nil value")
+
+            if isinstance(value, OptionalValue):
+                if i != len(output_values) - 1:
+                    # Usage of multiple optional values is not recommended:
+                    # https://docs.multiversx.com/developers/data/multi-values
+                    # Thus, here, we disallow them.
+                    raise ValueError("an optional value must be last among output values")
+
+                if parts_holder.is_focused_beyond_last_part():
+                    value.value = None
+                else:
+                    self._do_deserialize(parts_holder, [value.value])
+            elif isinstance(value, MultiValue):
+                self._do_deserialize(parts_holder, value.items)
+            elif isinstance(value, VariadicValues):
+                if i != len(output_values) - 1:
+                    raise ValueError("variadic values must be last among output values")
+
+                self._deserialize_variadic_values(parts_holder, value)
+            else:
+                self._deserialize_single_value(parts_holder, value)
+
+    def _deserialize_variadic_values(self, parts_holder: PartsHolder, value: VariadicValues):
+        if value.item_creator is None:
+            raise Exception("cannot decode list: item creator is None")
+
+        while not parts_holder.is_focused_beyond_last_part():
+            new_item = value.item_creator()
+
+            self._do_deserialize(parts_holder, [new_item])
+
+            value.items.append(new_item)
+
+    def _deserialize_single_value(self, parts_holder: PartsHolder, value: Any):
+        part = parts_holder.read_whole_focused_part()
+        self.codec.decode_top_level(part, value)
+        parts_holder.focus_on_next_part()
+
+    def _encode_parts(self, parts: List[bytes]) -> str:
+        parts_hex = [part.hex() for part in parts]
+        return self.parts_separator.join(parts_hex)
+
+    def _decode_into_parts(self, encoded: str) -> List[bytes]:
+        parts_hex = encoded.split(self.parts_separator)
+        parts = [bytes.fromhex(part_hex) for part_hex in parts_hex]
+        return parts

--- a/multiversx_sdk/abi/serializer_test.py
+++ b/multiversx_sdk/abi/serializer_test.py
@@ -1,0 +1,459 @@
+from typing import cast
+
+import pytest
+
+from multiversx_sdk.abi.address_value import AddressValue
+from multiversx_sdk.abi.biguint_value import BigUIntValue
+from multiversx_sdk.abi.bytes_value import BytesValue
+from multiversx_sdk.abi.enum_value import EnumValue
+from multiversx_sdk.abi.fields import *
+from multiversx_sdk.abi.list_value import ListValue
+from multiversx_sdk.abi.option_value import OptionValue
+from multiversx_sdk.abi.serializer import Serializer
+from multiversx_sdk.abi.small_int_values import *
+from multiversx_sdk.abi.string_value import StringValue
+from multiversx_sdk.abi.struct_value import StructValue
+from multiversx_sdk.abi.values_multi import *
+
+alice_pub_key = bytes.fromhex("0139472eff6886771a982f3083da5d421f24c29181e63888228dc81ca60d69e1")
+bob_pub_key = bytes.fromhex("8049d639e5a6980d1cd2392abcce41029cda74a1563523a202f09641cc2618f8")
+one_quintillion = 1_000_000_000_000_000_000
+
+
+def test_serialize():
+    serializer = Serializer(parts_separator="@")
+
+    # u8
+    data = serializer.serialize([
+        U8Value(0x42)
+    ])
+
+    assert data == "42"
+
+    # u16
+    data = serializer.serialize([
+        U16Value(0x4243)
+    ])
+
+    assert data == "4243"
+
+    # u8, u16
+    data = serializer.serialize([
+        U8Value(0x42),
+        U16Value(0x4243),
+    ])
+
+    assert data == "42@4243"
+
+    # optional (missing)
+    data = serializer.serialize([
+        U8Value(0x42),
+        OptionalValue(),
+    ])
+
+    assert data == "42"
+
+    # optional (provided)
+    data = serializer.serialize([
+        U8Value(0x42),
+        OptionalValue(U8Value(0x43)),
+    ])
+
+    assert data == "42@43"
+
+    # optional: should err because optional must be last
+    with pytest.raises(ValueError, match="^an optional value must be last among input values$"):
+        serializer.serialize([
+            OptionalValue(U8Value(0x43)),
+            U8Value(0x42),
+        ])
+
+    # multi<u8, u16, u32>
+    data = serializer.serialize([
+        MultiValue([
+            U8Value(0x42),
+            U16Value(0x4243),
+            U32Value(0x42434445),
+        ]),
+    ])
+
+    assert data == "42@4243@42434445"
+
+    # u8, multi<u8, u16, u32>
+    data = serializer.serialize([
+        U8Value(0x42),
+        MultiValue([
+            U8Value(0x42),
+            U16Value(0x4243),
+            U32Value(0x42434445),
+        ]),
+    ])
+
+    assert data == "42@42@4243@42434445"
+
+    # multi<multi<u8, u16>, multi<u8, u16>>
+    data = serializer.serialize([
+        MultiValue([
+            MultiValue([
+                U8Value(0x42),
+                U16Value(0x4243),
+            ]),
+            MultiValue([
+                U8Value(0x44),
+                U16Value(0x4445),
+            ]),
+        ]),
+    ])
+
+    assert data == "42@4243@44@4445"
+
+    # variadic, of different types
+    data = serializer.serialize([
+        VariadicValues([
+            U8Value(0x42),
+            U16Value(0x4243),
+        ]),
+    ])
+
+    # For now, the serializer does not perform such a strict type check.
+    # Although doable, it would be slightly complex and, if done, might be even dropped in the future
+    # (with respect to the decoder that is embedded in Rust-based smart contracts).
+    assert data == "42@4243"
+
+    # variadic<u8>, u8: should err because variadic must be last
+    with pytest.raises(ValueError, match="^variadic values must be last among input values$"):
+        serializer.serialize([
+            VariadicValues([
+                U8Value(0x42),
+                U8Value(0x43),
+            ]),
+            U8Value(0x44),
+        ])
+
+    # u8, variadic<u8>
+    data = serializer.serialize([
+        U8Value(0x41),
+        VariadicValues([
+            U8Value(0x42),
+            U8Value(0x43),
+        ]),
+    ])
+
+    assert data == "41@42@43"
+
+
+def test_deserialize():
+    serializer = Serializer(parts_separator="@")
+
+    # nil destination
+    with pytest.raises(ValueError, match="^cannot deserialize into nil value$"):
+        serializer.deserialize("", [None])
+
+    # u8
+    output_values = [
+        U8Value(),
+    ]
+
+    serializer.deserialize("42", output_values)
+
+    assert output_values == [
+        U8Value(0x42),
+    ]
+
+    # u16
+    output_values = [
+        U16Value(),
+    ]
+
+    serializer.deserialize("4243", output_values)
+
+    assert output_values == [
+        U16Value(0x4243),
+    ]
+
+    # u8, u16
+    output_values = [
+        U8Value(),
+        U16Value(),
+    ]
+
+    serializer.deserialize("42@4243", output_values)
+
+    assert output_values == [
+        U8Value(0x42),
+        U16Value(0x4243),
+    ]
+
+    # optional (missing)
+    output_values = [
+        U8Value(),
+        OptionalValue(U8Value()),
+    ]
+
+    serializer.deserialize("42", output_values)
+
+    assert output_values == [
+        U8Value(0x42),
+        OptionalValue(value=None),
+    ]
+
+    # optional (provided)
+    output_values = [
+        U8Value(),
+        OptionalValue(U8Value()),
+    ]
+
+    serializer.deserialize("42@43", output_values)
+
+    assert output_values == [
+        U8Value(0x42),
+        OptionalValue(U8Value(0x43)),
+    ]
+
+    # optional: should err because optional must be last
+    with pytest.raises(ValueError, match="^an optional value must be last among output values$"):
+        output_values = [
+            OptionalValue(U8Value()),
+            U8Value(),
+        ]
+
+        serializer.deserialize("43@42", output_values)
+
+    # multi<u8, u16, u32>
+    output_values = [
+        MultiValue([
+            U8Value(),
+            U16Value(),
+            U32Value(),
+        ]),
+    ]
+
+    serializer.deserialize("42@4243@42434445", output_values)
+
+    assert output_values == [
+        MultiValue([
+            U8Value(0x42),
+            U16Value(0x4243),
+            U32Value(0x42434445),
+        ]),
+    ]
+
+    # u8, multi<u8, u16, u32>
+    output_values = [
+        U8Value(),
+        MultiValue([
+            U8Value(),
+            U16Value(),
+            U32Value(),
+        ]),
+    ]
+
+    serializer.deserialize("42@42@4243@42434445", output_values)
+
+    assert output_values == [
+        U8Value(0x42),
+        MultiValue([
+            U8Value(0x42),
+            U16Value(0x4243),
+            U32Value(0x42434445),
+        ]),
+    ]
+
+    # empty: u8
+    destination = VariadicValues(
+        item_creator=lambda: U8Value()
+    )
+
+    serializer.deserialize("", [destination])
+
+    assert destination.items == [U8Value(0)]
+
+    # variadic<u8>
+    destination = VariadicValues(
+        item_creator=lambda: U8Value()
+    )
+
+    serializer.deserialize("2A@2B@2C", [destination])
+
+    assert destination.items == [
+        U8Value(0x2A),
+        U8Value(0x2B),
+        U8Value(0x2C),
+    ]
+
+    # variadic<u8>, with empty items
+    destination = VariadicValues(
+        item_creator=lambda: U8Value()
+    )
+
+    serializer.deserialize("@01@00@", [destination])
+
+    assert destination.items == [
+        U8Value(0x00),
+        U8Value(0x01),
+        U8Value(0x00),
+        U8Value(0x00),
+    ]
+
+    # variadic<u32>
+    destination = VariadicValues(
+        item_creator=lambda: U32Value()
+    )
+
+    serializer.deserialize("AABBCCDD@DDCCBBAA", [destination])
+
+    assert destination.items == [
+        U32Value(0xAABBCCDD),
+        U32Value(0xDDCCBBAA),
+    ]
+
+    # variadic<u8>, u8: should err because decoded value is too large
+    with pytest.raises(ValueError, match="^cannot decode \\(top-level\\) U8Value, because of: decoded value is too large or invalid \\(does not fit into 1 byte\\(s\\)\\): 256$"):
+        destination = VariadicValues(
+            item_creator=lambda: U8Value()
+        )
+
+        serializer.deserialize("0100", [destination])
+
+
+def test_real_world_multisig_propose_batch():
+    """
+    serialize input of multisig.proposeBatch(variadic<Action>
+    """
+
+    serializer = Serializer(parts_separator="@")
+
+    def create_esdt_token_payment(token_identifier: str, token_nonce: int, amount: int) -> StructValue:
+        return StructValue([
+            Field("token_identifier", StringValue(token_identifier)),
+            Field("token_nonce", U64Value(token_nonce)),
+            Field("amount", BigUIntValue(amount)),
+        ])
+
+    # First action: SendTransferExecuteEgld
+    first_action = EnumValue(
+        discriminant=5,
+        fields=[
+            Field("to", AddressValue(alice_pub_key)),
+            Field("egld_amount", BigUIntValue(one_quintillion)),
+            Field("opt_gas_limit", OptionValue(U64Value(15_000_000))),
+            Field("endpoint_name", BytesValue(b"example")),
+            Field("arguments", ListValue([
+                BytesValue(bytes([0x03, 0x42])),
+                BytesValue(bytes([0x07, 0x43])),
+            ])),
+        ],
+    )
+
+    # Second action: SendTransferExecuteEsdt
+    second_action = EnumValue(
+        discriminant=6,
+        fields=[
+            Field("to", AddressValue(alice_pub_key)),
+            Field("tokens", ListValue([
+                create_esdt_token_payment("beer", 0, one_quintillion),
+                create_esdt_token_payment("chocolate", 0, one_quintillion),
+            ])),
+            Field("opt_gas_limit", OptionValue(U64Value(15_000_000))),
+            Field("endpoint_name", BytesValue(b"example")),
+            Field("arguments", ListValue([
+                BytesValue(bytes([0x03, 0x42])),
+                BytesValue(bytes([0x07, 0x43])),
+            ])),
+        ],
+    )
+
+    data = serializer.serialize([
+        first_action,
+        second_action,
+    ])
+
+    data_expected = "@".join([
+        "05|0139472eff6886771a982f3083da5d421f24c29181e63888228dc81ca60d69e1|000000080de0b6b3a7640000|010000000000e4e1c0|000000076578616d706c65|00000002000000020342000000020743",
+        "06|0139472eff6886771a982f3083da5d421f24c29181e63888228dc81ca60d69e1|00000002|0000000462656572|0000000000000000|000000080de0b6b3a7640000|0000000963686f636f6c617465|0000000000000000|000000080de0b6b3a7640000|010000000000e4e1c0|000000076578616d706c65|00000002000000020342000000020743",
+    ])
+
+    # Drop the delimiters (were added for readability)
+    data_expected = data_expected.replace("|", "")
+
+    assert data == data_expected
+
+
+def test_real_world_multisig_get_pending_action_full_info():
+    """
+    deserialize output of multisig.getPendingActionFullInfo() -> variadic<ActionFullInfo>
+    """
+
+    serializer = Serializer(parts_separator="@")
+
+    data_hex = "".join([
+        "0000002A",
+        "0000002A",
+        "05|0139472eff6886771a982f3083da5d421f24c29181e63888228dc81ca60d69e1|000000080de0b6b3a7640000|010000000000e4e1c0|000000076578616d706c65|00000002000000020342000000020743",
+        "00000002|0139472eff6886771a982f3083da5d421f24c29181e63888228dc81ca60d69e1|8049d639e5a6980d1cd2392abcce41029cda74a1563523a202f09641cc2618f8",
+    ])
+
+    # Drop the delimiters (were added for readability)
+    data = data_hex.replace("|", "")
+
+    action_id = U32Value()
+    group_id = U32Value()
+
+    action_to = AddressValue()
+    action_egld_amount = BigUIntValue()
+    action_gas_limit = U64Value()
+    action_endpoint_name = BytesValue()
+    action_arguments = ListValue(
+        item_creator=lambda: BytesValue()
+    )
+
+    def action_fields_provider(discriminant: int) -> List[Field]:
+        if discriminant == 5:
+            return [
+                Field("to", action_to),
+                Field("egld_amount", action_egld_amount),
+                Field("opt_gas_limit", OptionValue(action_gas_limit)),
+                Field("endpoint_name", action_endpoint_name),
+                Field("arguments", action_arguments),
+            ]
+
+        return []
+
+    action = EnumValue(
+        fields_provider=action_fields_provider
+    )
+
+    signers = ListValue(
+        item_creator=lambda: AddressValue()
+    )
+
+    destination = VariadicValues(
+        item_creator=lambda: StructValue([
+            Field("action_id", action_id),
+            Field("group_id", group_id),
+            Field("action_data", action),
+            Field("signers", signers),
+        ]),
+    )
+
+    serializer.deserialize(data, [destination])
+
+    assert len(destination.items) == 1
+
+    # result[0].action_id and result[0].group_id
+    assert action_id.value == 42
+    assert group_id.value == 42
+
+    # result[0].action_data
+    assert action.discriminant == 5
+    assert action_to.value == alice_pub_key
+    assert action_egld_amount.value == one_quintillion
+    assert action_gas_limit.value == 15_000_000
+    assert action_endpoint_name.value == b"example"
+    assert len(action_arguments.items) == 2
+    assert cast(BytesValue, action_arguments.items[0]).value == bytes([0x03, 0x42])
+    assert cast(BytesValue, action_arguments.items[1]).value == bytes([0x07, 0x43])
+
+    # result[0].signers
+    assert cast(AddressValue, signers.items[0]).value == alice_pub_key
+    assert cast(AddressValue, signers.items[1]).value == bob_pub_key


### PR DESCRIPTION
This is part of a series of pull requests.

See: https://github.com/multiversx/mx-sdk-py/pull/32.

This can be reviewed side-by-side with:
 - https://github.com/multiversx/mx-sdk-abi-go/blob/main/abi/serializer.go
 - https://github.com/multiversx/mx-sdk-abi-go/blob/main/abi/serializer_test.go
 - https://github.com/multiversx/mx-sdk-abi-go/blob/main/abi/codec.go