### PR TITLE
Codecs (part 9): payload holders - set_value, get_value on some typed values

### DIFF
--- a/multiversx_sdk/abi/address_value.py
+++ b/multiversx_sdk/abi/address_value.py
@@ -41,3 +41,16 @@ class AddressValue:
         if len(pubkey) != PUBKEY_LENGTH:
             raise ValueError(f"public key (address) has invalid length: {len(pubkey)}")
 
+    def set_payload(self, value: Any):
+        pubkey = bytes(value)
+        self._check_pub_key_length(pubkey)
+        self.value = pubkey
+
+    def get_payload(self) -> Any:
+        return self.value
+
+    def __eq__(self, other: Any) -> bool:
+        return isinstance(other, AddressValue) and self.value == other.value
+
+    def __bytes__(self) -> bytes:
+        return self.value

--- a/multiversx_sdk/abi/address_value_test.py
+++ b/multiversx_sdk/abi/address_value_test.py
@@ -1,0 +1,29 @@
+import re
+from types import SimpleNamespace
+
+import pytest
+
+from multiversx_sdk.abi.address_value import AddressValue
+from multiversx_sdk.core.address import Address
+
+
+def test_set_payload_and_get_payload():
+    # Simple
+    pubkey = bytes.fromhex("0139472eff6886771a982f3083da5d421f24c29181e63888228dc81ca60d69e1")
+    value = AddressValue()
+    value.set_payload(pubkey)
+    assert value.get_payload() == pubkey
+
+    # Simple (from Address)
+    address = Address.new_from_bech32("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th")
+    value = AddressValue()
+    value.set_payload(address)
+    assert value.get_payload() == address.get_public_key()
+
+    # With errors
+    with pytest.raises(ValueError, match=re.escape("public key (address) has invalid length: 3")):
+        AddressValue().set_payload(bytes([1, 2, 3]))
+
+    # With errors
+    with pytest.raises(TypeError, match="cannot convert 'types.SimpleNamespace' object to bytes"):
+        AddressValue().set_payload(SimpleNamespace(a=1, b=2, c=3))

--- a/multiversx_sdk/abi/bigint_value.py
+++ b/multiversx_sdk/abi/bigint_value.py
@@ -40,3 +40,14 @@ class BigIntValue:
     def _signed_from_bytes(self, data: bytes) -> int:
         return int.from_bytes(data, byteorder="big", signed=True)
 
+    def set_payload(self, value: Any):
+        self.value = int(value)
+
+    def get_payload(self) -> Any:
+        return self.value
+
+    def __eq__(self, other: Any) -> bool:
+        return isinstance(other, BigIntValue) and self.value == other.value
+
+    def __int__(self):
+        return self.value

--- a/multiversx_sdk/abi/biguint_value.py
+++ b/multiversx_sdk/abi/biguint_value.py
@@ -41,3 +41,14 @@ class BigUIntValue:
     def _unsigned_from_bytes(self, data: bytes) -> int:
         return int.from_bytes(data, byteorder="big", signed=False)
 
+    def set_payload(self, value: Any):
+        self.value = int(value)
+
+    def get_payload(self) -> Any:
+        return self.value
+
+    def __eq__(self, other: Any) -> bool:
+        return isinstance(other, BigUIntValue) and self.value == other.value
+
+    def __int__(self):
+        return self.value

--- a/multiversx_sdk/abi/bool_value.py
+++ b/multiversx_sdk/abi/bool_value.py
@@ -46,3 +46,14 @@ class BoolValue:
 
         raise ValueError(f"unexpected boolean value: {data}")
 
+    def set_payload(self, value: Any):
+        self.value = bool(value)
+
+    def get_payload(self) -> Any:
+        return self.value
+
+    def __eq__(self, other: Any) -> bool:
+        return isinstance(other, BoolValue) and self.value == other.value
+
+    def __bool__(self) -> bool:
+        return self.value

--- a/multiversx_sdk/abi/bytes_value.py
+++ b/multiversx_sdk/abi/bytes_value.py
@@ -26,3 +26,17 @@ class BytesValue:
     def decode_top_level(self, data: bytes):
         self.value = data
 
+    def set_payload(self, value: Any):
+        if isinstance(value, str):
+            self.value = bytes(value, "utf-8")
+        else:
+            self.value = bytes(value)
+
+    def get_payload(self) -> Any:
+        return self.value
+
+    def __eq__(self, other: Any) -> bool:
+        return isinstance(other, BytesValue) and self.value == other.value
+
+    def __bytes__(self) -> bytes:
+        return self.value

--- a/multiversx_sdk/abi/bytes_value_test.py
+++ b/multiversx_sdk/abi/bytes_value_test.py
@@ -1,0 +1,21 @@
+from types import SimpleNamespace
+
+import pytest
+
+from multiversx_sdk.abi.bytes_value import BytesValue
+
+
+def test_set_payload_and_get_payload():
+    # Simple
+    value = BytesValue()
+    value.set_payload("hello")
+    assert value.get_payload() == b"hello"
+
+    # Simple
+    value = BytesValue()
+    value.set_payload(b"hello")
+    assert value.get_payload() == b"hello"
+
+    # With errors
+    with pytest.raises(TypeError, match="cannot convert 'types.SimpleNamespace' object to bytes"):
+        BytesValue().set_payload(SimpleNamespace(a=1, b=2, c=3))

--- a/multiversx_sdk/abi/codec.py
+++ b/multiversx_sdk/abi/codec.py
@@ -1,24 +1,24 @@
 
 import io
 
-from multiversx_sdk.abi.interface import SingleValue
+from multiversx_sdk.abi.interface import ISingleValue
 
 
 class Codec:
     def __init__(self) -> None:
         pass
 
-    def encode_nested(self, value: SingleValue) -> bytes:
+    def encode_nested(self, value: ISingleValue) -> bytes:
         buffer = io.BytesIO()
         value.encode_nested(buffer)
         return buffer.getvalue()
 
-    def encode_top_level(self, value: SingleValue) -> bytes:
+    def encode_top_level(self, value: ISingleValue) -> bytes:
         buffer = io.BytesIO()
         value.encode_top_level(buffer)
         return buffer.getvalue()
 
-    def decode_nested(self, data: bytes, value: SingleValue) -> None:
+    def decode_nested(self, data: bytes, value: ISingleValue) -> None:
         reader = io.BytesIO(data)
 
         try:
@@ -26,7 +26,7 @@ class Codec:
         except ValueError as e:
             raise ValueError(f"cannot decode (nested) {type(value)}, because of: {e}")
 
-    def decode_top_level(self, data: bytes, value: SingleValue) -> None:
+    def decode_top_level(self, data: bytes, value: ISingleValue) -> None:
         try:
             value.decode_top_level(data)
         except ValueError as e:

--- a/multiversx_sdk/abi/fields.py
+++ b/multiversx_sdk/abi/fields.py
@@ -1,11 +1,11 @@
 import io
 from typing import Any, Dict, List
 
-from multiversx_sdk.abi.interface import SingleValue
+from multiversx_sdk.abi.interface import ISingleValue
 
 
 class Field:
-    def __init__(self, name: str, value: SingleValue) -> None:
+    def __init__(self, name: str, value: ISingleValue) -> None:
         self.name = name
         self.value = value
 

--- a/multiversx_sdk/abi/interface.py
+++ b/multiversx_sdk/abi/interface.py
@@ -1,6 +1,17 @@
+import io
+from typing import Any, Protocol, runtime_checkable
+
+
+class IPayloadHolder(Protocol):
+    def set_payload(self, value: Any):
+        ...
+
+    def get_payload(self) -> Any:
+        ...
+
 
 @runtime_checkable
-class SingleValue(NativeObjectHolder, Protocol):
+class ISingleValue(IPayloadHolder, Protocol):
     def encode_nested(self, writer: io.BytesIO):
         ...
 

--- a/multiversx_sdk/abi/list_value_test.py
+++ b/multiversx_sdk/abi/list_value_test.py
@@ -1,0 +1,57 @@
+from types import SimpleNamespace
+
+import pytest
+
+from multiversx_sdk.abi.biguint_value import BigUIntValue
+from multiversx_sdk.abi.fields import Field
+from multiversx_sdk.abi.list_value import ListValue
+from multiversx_sdk.abi.small_int_values import U32Value
+from multiversx_sdk.abi.struct_value import StructValue
+
+
+def test_set_payload_and_get_payload():
+    # Simple
+    value = ListValue(item_creator=lambda: U32Value())
+    value.set_payload([1, 2, 3])
+    assert value.items == [U32Value(1), U32Value(2), U32Value(3)]
+    assert value.get_payload() == [1, 2, 3]
+
+    # Simple
+    value = ListValue(item_creator=lambda: BigUIntValue())
+    value.set_payload(range(4, 7))
+    assert value.items == [BigUIntValue(4), BigUIntValue(5), BigUIntValue(6)]
+    assert value.get_payload() == [4, 5, 6]
+
+    # Nested (with recursion)
+    value = ListValue(item_creator=lambda: StructValue([
+        Field("a", U32Value()),
+        Field("b", BigUIntValue())
+    ]))
+
+    value.set_payload([
+        {"a": 1, "b": 2},
+        {"a": 3, "b": 4},
+        {"a": 5, "b": 6}
+    ])
+
+    assert value.items == [
+        StructValue([Field("a", U32Value(1)), Field("b", BigUIntValue(2))]),
+        StructValue([Field("a", U32Value(3)), Field("b", BigUIntValue(4))]),
+        StructValue([Field("a", U32Value(5)), Field("b", BigUIntValue(6))])
+    ]
+
+    assert value.get_payload() == [
+        SimpleNamespace(a=1, b=2),
+        SimpleNamespace(a=3, b=4),
+        SimpleNamespace(a=5, b=6)
+    ]
+
+    # With errors
+    with pytest.raises(ValueError, match="populating a list from a native object requires the item creator to be set"):
+        value = ListValue()
+        value.set_payload([1, 2, 3])
+
+    # With errors
+    with pytest.raises(ValueError, match="cannot convert native value to list, because of: 'int' object is not iterable"):
+        value = ListValue(item_creator=lambda: U32Value())
+        value.set_payload(42)

--- a/multiversx_sdk/abi/option_value.py
+++ b/multiversx_sdk/abi/option_value.py
@@ -3,12 +3,12 @@ from typing import Any, Optional
 
 from multiversx_sdk.abi.constants import (OPTION_MARKER_FOR_ABSENT_VALUE,
                                           OPTION_MARKER_FOR_PRESENT_VALUE)
-from multiversx_sdk.abi.interface import SingleValue
+from multiversx_sdk.abi.interface import ISingleValue
 from multiversx_sdk.abi.shared import read_bytes_exactly
 
 
 class OptionValue:
-    def __init__(self, value: Optional[SingleValue] = None) -> None:
+    def __init__(self, value: Optional[ISingleValue] = None) -> None:
         self.value = value
 
     def encode_nested(self, writer: io.BytesIO):

--- a/multiversx_sdk/abi/serializer.py
+++ b/multiversx_sdk/abi/serializer.py
@@ -1,7 +1,7 @@
 from typing import Any, List, Sequence
 
 from multiversx_sdk.abi.codec import Codec
-from multiversx_sdk.abi.interface import SingleValue
+from multiversx_sdk.abi.interface import ISingleValue
 from multiversx_sdk.abi.multi_values import *
 from multiversx_sdk.abi.parts import PartsHolder
 
@@ -49,13 +49,13 @@ class Serializer:
                     raise ValueError("variadic values must be last among input values")
 
                 self._do_serialize(parts_holder, value.items)
-            elif isinstance(value, SingleValue):
+            elif isinstance(value, ISingleValue):
                 parts_holder.append_empty_part()
                 self._serialize_single_value(parts_holder, value)
             else:
                 raise ValueError(f"cannot serialize value of type: {type(value).__name__}")
 
-    def _serialize_single_value(self, parts_holder: PartsHolder, value: SingleValue):
+    def _serialize_single_value(self, parts_holder: PartsHolder, value: ISingleValue):
         data = self.codec.encode_top_level(value)
         parts_holder.append_to_last_part(data)
 
@@ -90,7 +90,7 @@ class Serializer:
                     raise ValueError("variadic values must be last among output values")
 
                 self._deserialize_variadic_values(parts_holder, value)
-            elif isinstance(value, SingleValue):
+            elif isinstance(value, ISingleValue):
                 self._deserialize_single_value(parts_holder, value)
             else:
                 raise ValueError(f"cannot deserialize value of type: {type(value).__name__}")
@@ -106,7 +106,7 @@ class Serializer:
 
             value.items.append(new_item)
 
-    def _deserialize_single_value(self, parts_holder: PartsHolder, value: SingleValue):
+    def _deserialize_single_value(self, parts_holder: PartsHolder, value: ISingleValue):
         part = parts_holder.read_whole_focused_part()
         self.codec.decode_top_level(part, value)
         parts_holder.focus_on_next_part()

--- a/multiversx_sdk/abi/small_int_values.py
+++ b/multiversx_sdk/abi/small_int_values.py
@@ -37,6 +37,15 @@ class SmallUIntValue:
         except OverflowError:
             raise ValueError(f"decoded value is too large or invalid (does not fit into {self._num_bytes} byte(s)): {self.value}")
 
+    def set_payload(self, value: Any):
+        self.value = int(value)
+
+    def get_payload(self) -> Any:
+        return self.value
+
+    def __int__(self):
+        return self.value
+
 
 class SmallIntValue:
     def __init__(self, num_bytes: int, value: int = 0) -> None:
@@ -69,6 +78,15 @@ class SmallIntValue:
             self.value.to_bytes(self._num_bytes, byteorder="big", signed=True)
         except OverflowError:
             raise ValueError(f"decoded value is too large or invalid (does not fit into {self._num_bytes} byte(s)): {self.value}")
+
+    def set_payload(self, value: Any):
+        self.value = int(value)
+
+    def get_payload(self) -> Any:
+        return self.value
+
+    def __int__(self):
+        return self.value
 
 
 class U8Value(SmallUIntValue):

--- a/multiversx_sdk/abi/string_value.py
+++ b/multiversx_sdk/abi/string_value.py
@@ -24,3 +24,22 @@ class StringValue:
     def decode_top_level(self, data: bytes):
         self.value = data.decode("utf-8")
 
+    def set_payload(self, value: Any):
+        if isinstance(value, bytes):
+            self.value = value.decode("utf-8")
+        elif isinstance(value, str):
+            self.value = value
+        else:
+            raise ValueError(f"cannot set payload for string (should be either a string or bytes, but got: {type(value)})")
+
+    def get_payload(self) -> Any:
+        return self.value
+
+    def __eq__(self, other: Any) -> bool:
+        return isinstance(other, StringValue) and self.value == other.value
+
+    def __str__(self) -> str:
+        return self.value
+
+    def __bytes__(self) -> bytes:
+        return self.value.encode("utf-8")

--- a/multiversx_sdk/abi/string_value_test.py
+++ b/multiversx_sdk/abi/string_value_test.py
@@ -1,0 +1,22 @@
+import re
+from types import SimpleNamespace
+
+import pytest
+
+from multiversx_sdk.abi.string_value import StringValue
+
+
+def test_set_payload_and_get_payload():
+    # Simple
+    value = StringValue()
+    value.set_payload("hello")
+    assert value.get_payload() == "hello"
+
+    # Simple
+    value = StringValue()
+    value.set_payload(b"hello")
+    assert value.get_payload() == "hello"
+
+    # With errors
+    with pytest.raises(ValueError, match=re.escape("cannot set payload for string (should be either a string or bytes, but got: <class 'types.SimpleNamespace'>)")):
+        StringValue().set_payload(SimpleNamespace(a=1, b=2, c=3))

--- a/multiversx_sdk/abi/tuple_value.py
+++ b/multiversx_sdk/abi/tuple_value.py
@@ -1,12 +1,12 @@
 import io
 from typing import Any, List
 
-from multiversx_sdk.abi.interface import SingleValue
+from multiversx_sdk.abi.interface import ISingleValue
 from multiversx_sdk.abi.shared import convert_native_value_to_list
 
 
 class TupleValue:
-    def __init__(self, fields: List[SingleValue]) -> None:
+    def __init__(self, fields: List[ISingleValue]) -> None:
         self.fields = fields
 
     def encode_nested(self, writer: io.BytesIO):

--- a/multiversx_sdk/abi/typesystem.py
+++ b/multiversx_sdk/abi/typesystem.py
@@ -1,6 +1,6 @@
 from typing import Any, Sequence
 
-from multiversx_sdk.abi.interface import SingleValue
+from multiversx_sdk.abi.interface import ISingleValue
 from multiversx_sdk.abi.multi_values import (MultiValue, OptionalValue,
                                              VariadicValues)
 
@@ -22,7 +22,7 @@ def is_typed_value(value: Any) -> bool:
 
 
 def is_single_value(value: Any) -> bool:
-    return isinstance(value, SingleValue)
+    return isinstance(value, ISingleValue)
 
 
 def is_multi_value(value: Any) -> bool:

--- a/multiversx_sdk/core/address.py
+++ b/multiversx_sdk/core/address.py
@@ -103,6 +103,9 @@ class Address:
     def serialize(self) -> bytes:
         return self.get_public_key()
 
+    def __bytes__(self) -> bytes:
+        return self.get_public_key()
+
 
 class AddressFactory:
     """A factory used to create address objects."""


### PR DESCRIPTION
This is part of a series of pull requests.

See: https://github.com/multiversx/mx-sdk-py/pull/32.

This brings partial support for converting typed values to native Python objects (and back).