### PR TITLE
Codecs (part 12): struct & option - set_payload(), get_payload()

### DIFF
--- a/multiversx_sdk/abi/option_value.py
+++ b/multiversx_sdk/abi/option_value.py
@@ -60,3 +60,25 @@ class OptionValue:
         reader = io.BytesIO(data_after_first_byte)
         self.value.decode_nested(reader)
 
+    def set_payload(self, value: Any):
+        if value is None:
+            self.value = None
+            return
+
+        if self.value is None:
+            raise ValueError("placeholder value of option should be set before calling set_payload")
+
+        if isinstance(value, OptionValue):
+            self.value = value.value
+            return
+
+        self.value.set_payload(value)
+
+    def get_payload(self) -> Any:
+        if self.value is None:
+            return None
+
+        return self.value.get_payload()
+
+    def __eq__(self, other: Any) -> bool:
+        return isinstance(other, OptionValue) and self.value == other.value

--- a/multiversx_sdk/abi/option_value_test.py
+++ b/multiversx_sdk/abi/option_value_test.py
@@ -1,0 +1,34 @@
+from types import SimpleNamespace
+
+import pytest
+
+from multiversx_sdk.abi.biguint_value import BigUIntValue
+from multiversx_sdk.abi.fields import Field
+from multiversx_sdk.abi.option_value import OptionValue
+from multiversx_sdk.abi.small_int_values import U32Value
+from multiversx_sdk.abi.struct_value import StructValue
+
+
+def test_set_payload_and_get_payload():
+    # Simple (provided)
+    value = OptionValue(U32Value())
+    value.set_payload(42)
+    assert value.get_payload() == 42
+
+    # Simple (missing)
+    value = OptionValue(U32Value())
+    value.set_payload(None)
+    assert value.get_payload() is None
+
+    # Nested
+    value = OptionValue(StructValue([
+        Field("a", U32Value()),
+        Field("b", BigUIntValue())
+    ]))
+
+    value.set_payload({"a": 41, "b": 42})
+    assert value.get_payload() == SimpleNamespace(a=41, b=42)
+
+    # With errors
+    with pytest.raises(ValueError, match="placeholder value of option should be set before calling set_payload"):
+        OptionValue().set_payload(42)

--- a/multiversx_sdk/abi/struct_value_test.py
+++ b/multiversx_sdk/abi/struct_value_test.py
@@ -1,0 +1,40 @@
+import re
+from types import SimpleNamespace
+
+import pytest
+
+from multiversx_sdk.abi.biguint_value import BigUIntValue
+from multiversx_sdk.abi.fields import Field
+from multiversx_sdk.abi.small_int_values import U32Value
+from multiversx_sdk.abi.struct_value import StructValue
+
+
+def test_set_payload_and_get_payload():
+    # With errors
+    with pytest.raises(ValueError, match=re.escape("cannot set payload for struct (should be either a dictionary or a list)")):
+        StructValue([]).set_payload(42)
+
+    value = StructValue([
+        Field("a", U32Value()),
+        Field("b", BigUIntValue())
+    ])
+
+    # From SimpleNamespace
+    value.set_payload(SimpleNamespace(a=41, b=42))
+    assert value.fields == [Field("a", U32Value(41)), Field("b", BigUIntValue(42))]
+    assert value.get_payload() == SimpleNamespace(a=41, b=42)
+
+    class Payload:
+        def __init__(self, a: int, b: int):
+            self.a = a
+            self.b = b
+
+    # Then, from object
+    value.set_payload(Payload(43, 44))
+    assert value.fields == [Field("a", U32Value(43)), Field("b", BigUIntValue(44))]
+    assert value.get_payload() == SimpleNamespace(a=43, b=44)
+
+    # Then, from dictionary
+    value.set_payload({"a": 45, "b": 46})
+    assert value.fields == [Field("a", U32Value(45)), Field("b", BigUIntValue(46))]
+    assert value.get_payload() == SimpleNamespace(a=45, b=46)


### PR DESCRIPTION
This is part of a series of pull requests.

See: https://github.com/multiversx/mx-sdk-py/pull/32.