### PR TITLE
Codecs (part 14): abi-based encoding & decoding

### DIFF
--- a/multiversx_sdk/abi/abi.py
+++ b/multiversx_sdk/abi/abi.py
@@ -1,0 +1,227 @@
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Dict, List, cast
+
+from multiversx_sdk.abi.abi_definition import (AbiDefinition,
+                                               EndpointDefinition,
+                                               EnumDefinition,
+                                               ParameterDefinition,
+                                               StructDefinition)
+from multiversx_sdk.abi.address_value import AddressValue
+from multiversx_sdk.abi.biguint_value import BigUIntValue
+from multiversx_sdk.abi.bool_value import BoolValue
+from multiversx_sdk.abi.bytes_value import BytesValue
+from multiversx_sdk.abi.enum_value import EnumValue
+from multiversx_sdk.abi.fields import Field
+from multiversx_sdk.abi.interface import IPayloadHolder
+from multiversx_sdk.abi.list_value import ListValue
+from multiversx_sdk.abi.option_value import OptionValue
+from multiversx_sdk.abi.optional_value import OptionalValue
+from multiversx_sdk.abi.serializer import Serializer
+from multiversx_sdk.abi.small_int_values import *
+from multiversx_sdk.abi.struct_value import StructValue
+from multiversx_sdk.abi.token_identifier_value import TokenIdentifierValue
+from multiversx_sdk.abi.tuple_value import TupleValue
+from multiversx_sdk.abi.type_formula import TypeFormula
+from multiversx_sdk.abi.type_formula_parser import TypeFormulaParser
+from multiversx_sdk.abi.variadic_values import VariadicValues
+from multiversx_sdk.core.constants import ARGS_SEPARATOR
+
+
+class Abi:
+    def __init__(self, definition: AbiDefinition) -> None:
+        self._type_formula_parser = TypeFormulaParser()
+        self._serializer = Serializer(parts_separator=ARGS_SEPARATOR)
+
+        self.definition = definition
+        self.custom_types_prototypes_by_name: Dict[str, Any] = {}
+        self.endpoints_prototypes_by_name: Dict[str, EndpointPrototype] = {}
+
+        for name in definition.types.enums:
+            self.custom_types_prototypes_by_name[name] = self._create_custom_type_prototype(name)
+
+        for struct_type in definition.types.structs:
+            self.custom_types_prototypes_by_name[struct_type] = self._create_custom_type_prototype(struct_type)
+
+        self.constructor_prototype = EndpointPrototype(
+            input_parameters=self._create_endpoint_input_prototypes(definition.constructor),
+            output_parameters=self._create_endpoint_output_prototypes(definition.constructor)
+        )
+
+        self.upgrade_constructor_prototype = EndpointPrototype(
+            input_parameters=self._create_endpoint_input_prototypes(definition.upgrade_constructor),
+            output_parameters=self._create_endpoint_output_prototypes(definition.upgrade_constructor)
+        )
+
+        for endpoint in definition.endpoints:
+            input_prototype = self._create_endpoint_input_prototypes(endpoint)
+            output_prototype = self._create_endpoint_output_prototypes(endpoint)
+
+            endpoint_prototype = EndpointPrototype(
+                input_parameters=input_prototype,
+                output_parameters=output_prototype
+            )
+
+            self.endpoints_prototypes_by_name[endpoint.name] = endpoint_prototype
+
+    def _create_custom_type_prototype(self, name: str) -> Any:
+        if name in self.definition.types.enums:
+            definition = self.definition.types.enums[name]
+            return self._create_enum_prototype(definition)
+        if name in self.definition.types.structs:
+            definition = self.definition.types.structs[name]
+            return self._create_struct_prototype(definition)
+
+        raise ValueError(f"cannot create prototype for custom type {name} not found")
+
+    def _create_enum_prototype(self, enum_definition: EnumDefinition) -> Any:
+        return EnumValue(fields_provider=lambda discriminant: self._provide_fields_for_enum_prototype(discriminant, enum_definition))
+
+    def _provide_fields_for_enum_prototype(self, discriminant: int, enum_definition: EnumDefinition) -> List[Field]:
+        for variant in enum_definition.variants:
+            if variant.discriminant != discriminant:
+                continue
+
+            fields_prototypes: List[Field] = []
+
+            for field_definition in variant.fields:
+                type_formula = self._type_formula_parser.parse_expression(field_definition.type)
+                field_value_prototype = self._create_prototype(type_formula)
+                field_prototype = Field(name=field_definition.name, value=field_value_prototype)
+                fields_prototypes.append(field_prototype)
+
+            return fields_prototypes
+
+        raise ValueError(f"cannot provide fields from enum {enum_definition.name}: variant with discriminant {discriminant} not found")
+
+    def _create_struct_prototype(self, struct_definition: StructDefinition) -> Any:
+        fields_prototypes: List[Field] = []
+
+        for field_definition in struct_definition.fields:
+            type_formula = self._type_formula_parser.parse_expression(field_definition.type)
+            field_value_prototype = self._create_prototype(type_formula)
+            field_prototype = Field(name=field_definition.name, value=field_value_prototype)
+            fields_prototypes.append(field_prototype)
+
+        return StructValue(fields_prototypes)
+
+    def _create_endpoint_input_prototypes(self, endpoint: EndpointDefinition) -> List[Any]:
+        prototypes: List[Any] = []
+
+        for parameter in endpoint.inputs:
+            parameter_prototype = self._create_parameter_prototype(parameter)
+            prototypes.append(parameter_prototype)
+
+        return prototypes
+
+    def _create_endpoint_output_prototypes(self, endpoint: EndpointDefinition) -> List[Any]:
+        prototypes: List[Any] = []
+
+        for parameter in endpoint.outputs:
+            parameter_prototype = self._create_parameter_prototype(parameter)
+            prototypes.append(parameter_prototype)
+
+        return prototypes
+
+    def _create_parameter_prototype(self, parameter: ParameterDefinition) -> Any:
+        type_formula = self._type_formula_parser.parse_expression(parameter.type)
+        return self._create_prototype(type_formula)
+
+    def encode_constructor_input_parameters(self, values: List[Any]) -> List[bytes]:
+        return self._do_encode_endpoint_input_parameters("constructor", self.constructor_prototype, values)
+
+    def encode_upgrade_constructor_input_parameters(self, values: List[Any]) -> List[bytes]:
+        return self._do_encode_endpoint_input_parameters("upgrade", self.upgrade_constructor_prototype, values)
+
+    def encode_endpoint_input_parameters(self, endpoint_name: str, values: List[Any]) -> List[bytes]:
+        endpoint_prototype = self._get_endpoint_prototype(endpoint_name)
+        return self._do_encode_endpoint_input_parameters(endpoint_name, endpoint_prototype, values)
+
+    def _do_encode_endpoint_input_parameters(self, endpoint_name: str, endpoint_prototype: 'EndpointPrototype', values: List[Any]):
+        if len(values) != len(endpoint_prototype.input_parameters):
+            raise ValueError(f"for {endpoint_name}, invalid value length: expected {len(endpoint_prototype.input_parameters)}, got {len(values)}")
+
+        input_values = deepcopy(endpoint_prototype.input_parameters)
+        input_values_as_native_object_holders = cast(List[IPayloadHolder], input_values)
+
+        # Populate the input values with the provided arguments
+        for i, arg in enumerate(values):
+            input_values_as_native_object_holders[i].set_payload(arg)
+
+        input_values_encoded = self._serializer.serialize_to_parts(input_values)
+        return input_values_encoded
+
+    def decode_endpoint_output_parameters(self, endpoint_name: str, encoded_values: List[bytes]) -> List[Any]:
+        endpoint_prototype = self._get_endpoint_prototype(endpoint_name)
+        output_values = deepcopy(endpoint_prototype.output_parameters)
+        self._serializer.deserialize_parts(encoded_values, output_values)
+
+        output_values_as_native_object_holders = cast(List[IPayloadHolder], output_values)
+        output_native_values = [value.get_payload() for value in output_values_as_native_object_holders]
+        return output_native_values
+
+    def _get_custom_type_prototype(self, type_name: str) -> Any:
+        type_prototype = self.custom_types_prototypes_by_name.get(type_name)
+
+        if not type_prototype:
+            raise ValueError(f"custom type '{type_name}' not found")
+
+        return type_prototype
+
+    def _get_endpoint_prototype(self, endpoint_name: str) -> 'EndpointPrototype':
+        endpoint_prototype = self.endpoints_prototypes_by_name.get(endpoint_name)
+
+        if not endpoint_prototype:
+            raise ValueError(f"endpoint '{endpoint_name}' not found")
+
+        return endpoint_prototype
+
+    def _create_prototype(self, type_formula: TypeFormula) -> Any:
+        name = type_formula.name
+
+        if name == "bool":
+            return BoolValue()
+        if name == "u32":
+            return U32Value()
+        if name == "u64":
+            return U64Value()
+        if name == "BigUint":
+            return BigUIntValue()
+        if name == "bytes":
+            return BytesValue()
+        if name == "Address":
+            return AddressValue()
+        if name == "TokenIdentifier":
+            return TokenIdentifierValue()
+        if name == "CodeMetadata":
+            return BytesValue()
+        if name == "tuple":
+            return TupleValue([self._create_prototype(type_parameter) for type_parameter in type_formula.type_parameters])
+        if name == "Option":
+            type_parameter = type_formula.type_parameters[0]
+            return OptionValue(self._create_prototype(type_parameter))
+        if name == "List":
+            type_parameter = type_formula.type_parameters[0]
+            return ListValue([], item_creator=lambda: self._create_prototype(type_parameter))
+        if name == "optional":
+            # The prototype of an optional is provided a value.
+            type_parameter = type_formula.type_parameters[0]
+            return OptionalValue(self._create_prototype(type_parameter))
+        if name == "variadic":
+            type_parameter = type_formula.type_parameters[0]
+            return VariadicValues([], item_creator=lambda: self._create_prototype(type_parameter))
+
+        # Handle custom types
+        type_prototype = self._get_custom_type_prototype(name)
+        return deepcopy(type_prototype)
+
+    @classmethod
+    def load(cls, path: Path) -> 'Abi':
+        definition = AbiDefinition.load(path)
+        return cls(definition)
+
+
+class EndpointPrototype:
+    def __init__(self, input_parameters: List[Any], output_parameters: List[Any]) -> None:
+        self.input_parameters = input_parameters
+        self.output_parameters = output_parameters

--- a/multiversx_sdk/abi/abi.py
+++ b/multiversx_sdk/abi/abi.py
@@ -15,10 +15,12 @@ from multiversx_sdk.abi.enum_value import EnumValue
 from multiversx_sdk.abi.fields import Field
 from multiversx_sdk.abi.interface import IPayloadHolder
 from multiversx_sdk.abi.list_value import ListValue
+from multiversx_sdk.abi.multi_value import MultiValue
 from multiversx_sdk.abi.option_value import OptionValue
 from multiversx_sdk.abi.optional_value import OptionalValue
 from multiversx_sdk.abi.serializer import Serializer
 from multiversx_sdk.abi.small_int_values import *
+from multiversx_sdk.abi.string_value import StringValue
 from multiversx_sdk.abi.struct_value import StructValue
 from multiversx_sdk.abi.token_identifier_value import TokenIdentifierValue
 from multiversx_sdk.abi.tuple_value import TupleValue
@@ -181,14 +183,28 @@ class Abi:
 
         if name == "bool":
             return BoolValue()
+        if name == "u8":
+            return U8Value()
+        if name == "u16":
+            return U16Value()
         if name == "u32":
             return U32Value()
         if name == "u64":
             return U64Value()
+        if name == "i8":
+            return I8Value()
+        if name == "i16":
+            return I16Value()
+        if name == "i32":
+            return I32Value()
         if name == "BigUint":
+            return BigUIntValue()
+        if name == "BigInt":
             return BigUIntValue()
         if name == "bytes":
             return BytesValue()
+        if name == "utf-8 string":
+            return StringValue()
         if name == "Address":
             return AddressValue()
         if name == "TokenIdentifier":
@@ -204,12 +220,14 @@ class Abi:
             type_parameter = type_formula.type_parameters[0]
             return ListValue([], item_creator=lambda: self._create_prototype(type_parameter))
         if name == "optional":
-            # The prototype of an optional is provided a value.
+            # The prototype of an optional is provided a value (the placeholder).
             type_parameter = type_formula.type_parameters[0]
             return OptionalValue(self._create_prototype(type_parameter))
         if name == "variadic":
             type_parameter = type_formula.type_parameters[0]
             return VariadicValues([], item_creator=lambda: self._create_prototype(type_parameter))
+        if name == "multi":
+            return MultiValue([self._create_prototype(type_parameter) for type_parameter in type_formula.type_parameters])
 
         # Handle custom types
         type_prototype = self._get_custom_type_prototype(name)

--- a/multiversx_sdk/abi/abi_test.py
+++ b/multiversx_sdk/abi/abi_test.py
@@ -1,0 +1,223 @@
+from pathlib import Path
+from types import SimpleNamespace
+from typing import List, Optional
+
+from multiversx_sdk.abi.abi import Abi
+from multiversx_sdk.abi.abi_definition import ParameterDefinition
+from multiversx_sdk.abi.address_value import AddressValue
+from multiversx_sdk.abi.biguint_value import BigUIntValue
+from multiversx_sdk.abi.bytes_value import BytesValue
+from multiversx_sdk.abi.enum_value import EnumValue
+from multiversx_sdk.abi.fields import Field
+from multiversx_sdk.abi.list_value import ListValue
+from multiversx_sdk.abi.option_value import OptionValue
+from multiversx_sdk.abi.small_int_values import U64Value
+from multiversx_sdk.abi.string_value import StringValue
+from multiversx_sdk.abi.struct_value import StructValue
+from multiversx_sdk.abi.variadic_values import VariadicValues
+from multiversx_sdk.core.address import Address
+
+testdata = Path(__file__).parent.parent / "testutils" / "testdata"
+
+
+def test_abi():
+    abi = Abi.load(testdata / "adder.abi.json")
+
+    assert abi.definition.constructor.name == "constructor"
+    assert abi.definition.constructor.inputs == [ParameterDefinition("initial_value", "BigUint")]
+    assert abi.definition.constructor.outputs == []
+
+    assert abi.definition.upgrade_constructor.name == "upgrade_constructor"
+    assert abi.definition.upgrade_constructor.inputs == [ParameterDefinition("initial_value", "BigUint")]
+    assert abi.definition.upgrade_constructor.outputs == []
+
+    assert abi.definition.endpoints[0].name == "getSum"
+    assert abi.definition.endpoints[0].inputs == []
+    assert abi.definition.endpoints[0].outputs == [ParameterDefinition("", "BigUint")]
+
+    assert abi.definition.endpoints[1].name == "add"
+    assert abi.definition.endpoints[1].inputs == [ParameterDefinition("value", "BigUint")]
+    assert abi.definition.endpoints[1].outputs == []
+
+    assert abi.definition.types.enums == {}
+    assert abi.definition.types.structs == {}
+    assert abi.custom_types_prototypes_by_name == {}
+
+    assert abi.constructor_prototype.input_parameters == [BigUIntValue()]
+    assert abi.constructor_prototype.output_parameters == []
+    assert abi.upgrade_constructor_prototype.input_parameters == [BigUIntValue()]
+    assert abi.upgrade_constructor_prototype.output_parameters == []
+
+    assert abi.endpoints_prototypes_by_name["getSum"].input_parameters == []
+    assert abi.endpoints_prototypes_by_name["getSum"].output_parameters == [BigUIntValue()]
+    assert abi.endpoints_prototypes_by_name["add"].input_parameters == [BigUIntValue()]
+    assert abi.endpoints_prototypes_by_name["add"].output_parameters == []
+
+
+def test_encode_endpoint_input_parameters_real_world_multisig_propose_batch():
+    abi = Abi.load(testdata / "multisig-full.abi.json")
+
+    alice = Address.from_bech32("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th")
+    expected_encoded_values = [
+        bytes.fromhex("05|0139472eff6886771a982f3083da5d421f24c29181e63888228dc81ca60d69e1|000000080de0b6b3a7640000|010000000000e4e1c0|000000076578616d706c65|00000002000000020342000000020743".replace("|", ""))
+    ]
+
+    # All values untyped, structure as dictionary.
+    encoded_values = abi.encode_endpoint_input_parameters(
+        endpoint_name="proposeBatch",
+        values=[
+            [
+                {
+                    "__discriminant__": 5,
+                    "0": {
+                        "to": alice,
+                        "egld_amount": 1000000000000000000,
+                        "endpoint_name": "example",
+                        "arguments": [
+                            bytes([0x03, 0x42]),
+                            bytes([0x07, 0x43])
+                        ],
+                        "opt_gas_limit": 15_000_000
+                    }
+                }
+            ]
+        ]
+    )
+
+    assert encoded_values == expected_encoded_values
+
+    # All values untyped, structure as simple object.
+    encoded_values = abi.encode_endpoint_input_parameters(
+        endpoint_name="proposeBatch",
+        values=[
+            [
+                {
+                    "__discriminant__": 5,
+                    "0": SimpleNamespace(
+                        to=alice,
+                        egld_amount=1000000000000000000,
+                        endpoint_name="example",
+                        arguments=[
+                            bytes([0x03, 0x42]),
+                            bytes([0x07, 0x43])
+                        ],
+                        opt_gas_limit=15_000_000
+                    )
+                }
+            ]
+        ]
+    )
+
+    assert encoded_values == expected_encoded_values
+
+    # All values untyped, structure as simple object (custom class)
+    class CallActionData:
+        def __init__(self, to: Address, egld_amount: int, endpoint_name: str, arguments: List[bytes], opt_gas_limit: Optional[int] = None):
+            self.to = to
+            self.egld_amount = egld_amount
+            self.endpoint_name = endpoint_name
+            self.arguments = arguments
+            self.opt_gas_limit = opt_gas_limit
+
+    encoded_values = abi.encode_endpoint_input_parameters(
+        endpoint_name="proposeBatch",
+        values=[
+            [
+                {
+                    "__discriminant__": 5,
+                    "0": CallActionData(
+                        to=alice,
+                        egld_amount=1000000000000000000,
+                        endpoint_name="example",
+                        arguments=[
+                            bytes([0x03, 0x42]),
+                            bytes([0x07, 0x43])
+                        ],
+                        opt_gas_limit=15_000_000
+                    )
+                }
+            ]
+        ]
+    )
+
+    assert encoded_values == expected_encoded_values
+
+    # Some values typed, structure as dictionary.
+    encoded_values = abi.encode_endpoint_input_parameters(
+        endpoint_name="proposeBatch",
+        values=[
+            [
+                {
+                    "__discriminant__": 5,
+                    "0": {
+                        "to": AddressValue.from_address(alice),
+                        "egld_amount": 1000000000000000000,
+                        "endpoint_name": StringValue("example"),
+                        "arguments": [
+                            bytes([0x03, 0x42]),
+                            bytes([0x07, 0x43])
+                        ],
+                        "opt_gas_limit": U64Value(15_000_000)
+                    }
+                }
+            ]
+        ]
+    )
+
+    # All values typed.
+    encoded_values = abi.encode_endpoint_input_parameters(
+        endpoint_name="proposeBatch",
+        values=[
+            VariadicValues(
+                [
+                    EnumValue(
+                        discriminant=5,
+                        fields=[
+                            Field("0", StructValue([
+                                Field("to", AddressValue.from_address(alice)),
+                                Field("egld_amount", BigUIntValue(1000000000000000000)),
+                                Field("opt_gas_limit", OptionValue(U64Value(15_000_000))),
+                                Field("endpoint_name", BytesValue(b"example")),
+                                Field("arguments", ListValue([
+                                    BytesValue(bytes([0x03, 0x42])),
+                                    BytesValue(bytes([0x07, 0x43])),
+                                ])),
+                            ])),
+                        ],
+                    )
+                ]
+            )
+        ]
+    )
+
+    assert encoded_values == expected_encoded_values
+
+
+def test_decode_endpoint_output_parameters_real_world_multisig_get_pending_action_full_info():
+    abi = Abi.load(testdata / "multisig-full.abi.json")
+
+    data_hex = "".join([
+        "0000002A",
+        "0000002A",
+        "05|0139472eff6886771a982f3083da5d421f24c29181e63888228dc81ca60d69e1|000000080de0b6b3a7640000|010000000000e4e1c0|000000076578616d706c65|00000002000000020342000000020743",
+        "00000002|0139472eff6886771a982f3083da5d421f24c29181e63888228dc81ca60d69e1|8049d639e5a6980d1cd2392abcce41029cda74a1563523a202f09641cc2618f8",
+    ]).replace("|", "")
+
+    data = bytes.fromhex(data_hex)
+    [[action_full_info]] = abi.decode_endpoint_output_parameters("getPendingActionFullInfo", [data])
+
+    assert action_full_info.action_id == 42
+    assert action_full_info.group_id == 42
+    assert action_full_info.action_data.__discriminant__ == 5
+
+    action_data_0 = getattr(action_full_info.action_data, "0")
+    assert action_data_0.to == Address.from_bech32("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th").get_public_key()
+    assert action_data_0.egld_amount == 1000000000000000000
+    assert action_data_0.opt_gas_limit == 15000000
+    assert action_data_0.endpoint_name == b"example"
+    assert action_data_0.arguments == [bytes([0x03, 0x42]), bytes([0x07, 0x43])]
+
+    assert action_full_info.signers == [
+        Address.from_bech32("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th").get_public_key(),
+        Address.from_bech32("erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx").get_public_key(),
+    ]

--- a/multiversx_sdk/abi/abi_test.py
+++ b/multiversx_sdk/abi/abi_test.py
@@ -83,7 +83,7 @@ def test_decode_endpoint_output_parameters_artificial_contract():
     assert decoded_values == [["UTK-2f80e9", 0, 1000000000000000000]]
 
 
-def test_encode_endpoint_input_parameters_real_world_multisig_propose_batch():
+def test_encode_endpoint_input_parameters_multisig_propose_batch():
     abi = Abi.load(testdata / "multisig-full.abi.json")
 
     alice = Address.from_bech32("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th")
@@ -222,7 +222,7 @@ def test_encode_endpoint_input_parameters_real_world_multisig_propose_batch():
     assert encoded_values == expected_encoded_values
 
 
-def test_decode_endpoint_output_parameters_real_world_multisig_get_pending_action_full_info():
+def test_decode_endpoint_output_parameters_multisig_get_pending_action_full_info():
     abi = Abi.load(testdata / "multisig-full.abi.json")
 
     data_hex = "".join([

--- a/multiversx_sdk/abi/abi_test.py
+++ b/multiversx_sdk/abi/abi_test.py
@@ -54,6 +54,35 @@ def test_abi():
     assert abi.endpoints_prototypes_by_name["add"].output_parameters == []
 
 
+def test_encode_endpoint_input_parameters_artificial_contract():
+    abi = Abi.load(testdata / "artificial.abi.json")
+
+    encoded_values = abi.encode_endpoint_input_parameters(
+        endpoint_name="yellow",
+        values=[[42, "hello", True]]
+    )
+
+    assert len(encoded_values) == 3
+    assert encoded_values[0].hex() == "2a"
+    assert encoded_values[1].hex() == "hello".encode().hex()
+    assert encoded_values[2].hex() == "01"
+
+
+def test_decode_endpoint_output_parameters_artificial_contract():
+    abi = Abi.load(testdata / "artificial.abi.json")
+
+    decoded_values = abi.decode_endpoint_output_parameters(
+        endpoint_name="blue",
+        encoded_values=[
+            "UTK-2f80e9".encode(),
+            bytes([0x00]),
+            bytes.fromhex("0de0b6b3a7640000")
+        ]
+    )
+
+    assert decoded_values == [["UTK-2f80e9", 0, 1000000000000000000]]
+
+
 def test_encode_endpoint_input_parameters_real_world_multisig_propose_batch():
     abi = Abi.load(testdata / "multisig-full.abi.json")
 

--- a/multiversx_sdk/abi/tuple_value.py
+++ b/multiversx_sdk/abi/tuple_value.py
@@ -30,3 +30,22 @@ class TupleValue:
         reader = io.BytesIO(data)
         self.decode_nested(reader)
 
+    def set_payload(self, value: Any):
+        native_list, ok = convert_native_value_to_list(value, raise_on_failure=False)
+        if ok:
+            if len(self.fields) != len(native_list):
+                raise ValueError(f"the number of fields ({len(self.fields)}) does not match the number of provided native values ({len(native_list)})")
+
+            for i, field in enumerate(self.fields):
+                field.set_payload(native_list[i])
+
+            return
+
+        raise ValueError("cannot set payload for tuple (should be either a tuple or a list)")
+
+    def get_payload(self) -> Any:
+        native_values = [field.get_payload() for field in self.fields]
+        return tuple(native_values)
+
+    def __eq__(self, other: Any) -> bool:
+        return isinstance(other, TupleValue) and self.fields == other.fields

--- a/multiversx_sdk/abi/tuple_value_test.py
+++ b/multiversx_sdk/abi/tuple_value_test.py
@@ -1,0 +1,28 @@
+import re
+
+import pytest
+
+from multiversx_sdk.abi.small_int_values import U32Value
+from multiversx_sdk.abi.string_value import StringValue
+from multiversx_sdk.abi.tuple_value import TupleValue
+
+
+def test_set_payload_and_get_payload():
+    # With errors
+    with pytest.raises(ValueError, match=re.escape("cannot set payload for tuple (should be either a tuple or a list)")):
+        TupleValue([]).set_payload(42)
+
+    value = TupleValue([
+        U32Value(),
+        StringValue(),
+    ])
+
+    # From tuple
+    value.set_payload((41, "hello"))
+    assert value.fields == [U32Value(41), StringValue("hello")]
+    assert value.get_payload() == (41, "hello")
+
+    # From list
+    value.set_payload([42, "world"])
+    assert value.fields == [U32Value(42), StringValue("world")]
+    assert value.get_payload() == (42, "world")

--- a/multiversx_sdk/testutils/testdata/artificial.abi.json
+++ b/multiversx_sdk/testutils/testdata/artificial.abi.json
@@ -1,0 +1,45 @@
+{
+  "name": "Artificial",
+  "constructor": {
+    "inputs": [
+      {
+        "name": "a",
+        "type": "utf-8 string"
+      }
+    ],
+    "outputs": []
+  },
+  "upgradeConstructor": {
+    "inputs": [
+      {
+        "name": "a",
+        "type": "u8"
+      }
+    ],
+    "outputs": []
+  },
+  "endpoints": [
+    {
+      "name": "blue",
+      "mutability": "readonly",
+      "inputs": [],
+      "outputs": [
+        {
+          "type": "optional<multi<TokenIdentifier,u64,BigUint>>"
+        }
+      ]
+    },
+    {
+      "name": "yellow",
+      "mutability": "mutable",
+      "inputs": [
+        {
+          "name": "value",
+          "type": "multi<u32, bytes, bool>"
+        }
+      ],
+      "outputs": []
+    }
+  ],
+  "types": {}
+}


### PR DESCRIPTION
This is part of a series of pull requests.

See: https://github.com/multiversx/mx-sdk-py/pull/32.

Changes:

 - Define the `Abi` component, able to encode & decode endpoint parameters. When the component is initialized, it reads the ABI definitions and prepares value prototypes (typed values) for endpoint parameters & custom types. Then, when appropriate, it clones these prototypes and populates them with native Python values / gets Python values out of them.
 - Add missing tests for tuples etc.