### PR TITLE
Ensure all bytes are deserialized

### DIFF
--- a/multiversx_sdk/abi/serializer.py
+++ b/multiversx_sdk/abi/serializer.py
@@ -69,6 +69,9 @@ class Serializer:
         parts_holder = PartsHolder(parts)
         self._do_deserialize(parts_holder, output_values)
 
+        if not parts_holder.is_focused_beyond_last_part():
+            raise Exception("not all parts have been deserialized")
+
     def _do_deserialize(self, parts_holder: PartsHolder, output_values: Sequence[Any]):
         for i, value in enumerate(output_values):
             if value is None:

--- a/multiversx_sdk/abi/serializer_test.py
+++ b/multiversx_sdk/abi/serializer_test.py
@@ -186,6 +186,15 @@ def test_deserialize():
         U16Value(0x4243),
     ]
 
+    # u8, u16
+    output_values = [
+        U8Value(),
+        U16Value(),
+    ]
+
+    with pytest.raises(Exception, match="not all parts have been deserialized"):
+        serializer.deserialize("42@4243@44", output_values)
+
     # optional (missing)
     output_values = [
         U8Value(),


### PR DESCRIPTION
Now raising an `Exception` if not all provided bytes have been deserialized when decoding values into `TypedValues`.