### PR TITLE
Load multiple signers from pem file

### DIFF
--- a/multiversx_sdk/wallet/user_signer.py
+++ b/multiversx_sdk/wallet/user_signer.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import List
 
 from multiversx_sdk.wallet.errors import ErrCannotSign
 from multiversx_sdk.wallet.interfaces import ISignature
@@ -19,6 +20,11 @@ class UserSigner:
     def from_pem_file(cls, path: Path, index: int = 0) -> 'UserSigner':
         secret_key = UserPEM.from_file(path, index).secret_key
         return UserSigner(secret_key)
+
+    @classmethod
+    def from_pem_file_all(cls, path: Path) -> List['UserSigner']:
+        users = UserPEM.from_file_all(path)
+        return [UserSigner(user.secret_key) for user in users]
 
     @classmethod
     def from_wallet(cls, path: Path, password: str) -> 'UserSigner':

--- a/multiversx_sdk/wallet/user_test.py
+++ b/multiversx_sdk/wallet/user_test.py
@@ -43,6 +43,15 @@ def test_user_signer_from_pem_file():
     assert Address(pubkey.buffer, "erd").to_bech32() == "erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8"
 
 
+def test_load_signers_from_pem():
+    signers = UserSigner.from_pem_file_all(testwallets / "multipleUserKeys.pem")
+
+    assert len(signers) == 3
+    assert Address(signers[0].get_pubkey().buffer, "erd").to_bech32() == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
+    assert Address(signers[1].get_pubkey().buffer, "erd").to_bech32() == "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx"
+    assert Address(signers[2].get_pubkey().buffer, "erd").to_bech32() == "erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8"
+
+
 def test_user_wallet_to_keyfile_object_using_known_test_wallets_with_their_randomness():
     alice_secret_key = UserSecretKey.from_string("413f42575f7f26fad3317a778771212fdb80245850981e48b58a4f25e344e8f9")
     alice_wallet = UserWallet.from_secret_key(alice_secret_key, "password", Randomness(


### PR DESCRIPTION
We were able to load multiple `UserPEM`s from file but not multiple `UserSigner`s. 