### PR TITLE
Support for instantiating address and bytes values from dictionary

### DIFF
--- a/multiversx_sdk/abi/address_value.py
+++ b/multiversx_sdk/abi/address_value.py
@@ -60,7 +60,7 @@ class AddressValue:
         if hex_address:
             return bytes.fromhex(hex_address)
 
-        raise ValueError("cannot extract pubkey from dictionary")
+        raise ValueError("cannot extract pubkey from dictionary: missing 'bech32' or 'hex' keys")
 
     def get_payload(self) -> Any:
         return self.value

--- a/multiversx_sdk/abi/address_value.py
+++ b/multiversx_sdk/abi/address_value.py
@@ -1,8 +1,8 @@
 import io
-from typing import Any, Protocol
+from typing import Any, Dict, Protocol, cast
 
 from multiversx_sdk.abi.shared import read_bytes_exactly
-from multiversx_sdk.core.address import PUBKEY_LENGTH
+from multiversx_sdk.core.address import PUBKEY_LENGTH, Address
 
 
 class IAddress(Protocol):
@@ -42,9 +42,25 @@ class AddressValue:
             raise ValueError(f"public key (address) has invalid length: {len(pubkey)}")
 
     def set_payload(self, value: Any):
-        pubkey = bytes(value)
+        if isinstance(value, dict):
+            value = cast(Dict[str, str], value)
+            pubkey = self._extract_pubkey_from_dict(value)
+        else:
+            pubkey = bytes(value)
+
         self._check_pub_key_length(pubkey)
         self.value = pubkey
+
+    def _extract_pubkey_from_dict(self, value: Dict[str, str]) -> bytes:
+        bech32_address = value.get("bech32", None)
+        if bech32_address:
+            return Address.new_from_bech32(bech32_address).get_public_key()
+
+        hex_address = value.get("hex", None)
+        if hex_address:
+            return bytes.fromhex(hex_address)
+
+        raise ValueError("cannot extract pubkey from dictionary")
 
     def get_payload(self) -> Any:
         return self.value

--- a/multiversx_sdk/abi/address_value_test.py
+++ b/multiversx_sdk/abi/address_value_test.py
@@ -47,3 +47,7 @@ def test_set_payload_and_get_payload():
     # With errors
     with pytest.raises(TypeError, match="cannot convert 'types.SimpleNamespace' object to bytes"):
         AddressValue().set_payload(SimpleNamespace(a=1, b=2, c=3))
+
+    # With errors
+    with pytest.raises(ValueError, match="cannot extract pubkey from dictionary"):
+        AddressValue().set_payload({})

--- a/multiversx_sdk/abi/address_value_test.py
+++ b/multiversx_sdk/abi/address_value_test.py
@@ -49,5 +49,5 @@ def test_set_payload_and_get_payload():
         AddressValue().set_payload(SimpleNamespace(a=1, b=2, c=3))
 
     # With errors
-    with pytest.raises(ValueError, match="cannot extract pubkey from dictionary"):
+    with pytest.raises(ValueError, match="cannot extract pubkey from dictionary: missing 'bech32' or 'hex' keys"):
         AddressValue().set_payload({})

--- a/multiversx_sdk/abi/address_value_test.py
+++ b/multiversx_sdk/abi/address_value_test.py
@@ -20,6 +20,26 @@ def test_set_payload_and_get_payload():
     value.set_payload(address)
     assert value.get_payload() == address.get_public_key()
 
+    # From dict using a bech32 address
+    address = Address.new_from_bech32("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th")
+    value = AddressValue()
+    value.set_payload(
+        {
+            "bech32": address.to_bech32()
+        }
+    )
+    assert value.get_payload() == address.get_public_key()
+
+    # From dict using a hex address
+    address = Address.new_from_bech32("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th")
+    value = AddressValue()
+    value.set_payload(
+        {
+            "hex": address.to_hex()
+        }
+    )
+    assert value.get_payload() == address.get_public_key()
+
     # With errors
     with pytest.raises(ValueError, match=re.escape("public key (address) has invalid length: 3")):
         AddressValue().set_payload(bytes([1, 2, 3]))

--- a/multiversx_sdk/abi/bytes_value.py
+++ b/multiversx_sdk/abi/bytes_value.py
@@ -37,7 +37,7 @@ class BytesValue:
         hex_value = value.get("hex", None)
 
         if not hex_value:
-            raise ValueError("cannot get value from dictionary")
+            raise ValueError("cannot get value from dictionary: missing 'hex' key")
 
         return bytes.fromhex(hex_value)
 

--- a/multiversx_sdk/abi/bytes_value.py
+++ b/multiversx_sdk/abi/bytes_value.py
@@ -1,7 +1,5 @@
-
-
 import io
-from typing import Any
+from typing import Any, Dict, cast
 
 from multiversx_sdk.abi.shared import (decode_length, encode_length,
                                        read_bytes_exactly)
@@ -29,8 +27,19 @@ class BytesValue:
     def set_payload(self, value: Any):
         if isinstance(value, str):
             self.value = bytes(value, "utf-8")
+        elif isinstance(value, dict):
+            value = cast(Dict[str, str], value)
+            self.value = self._extract_value_from_dict(value)
         else:
             self.value = bytes(value)
+
+    def _extract_value_from_dict(self, value: Dict[str, str]) -> bytes:
+        hex_value = value.get("hex", None)
+
+        if not hex_value:
+            raise ValueError("cannot get value from dictionary")
+
+        return bytes.fromhex(hex_value)
 
     def get_payload(self) -> Any:
         return self.value

--- a/multiversx_sdk/abi/bytes_value_test.py
+++ b/multiversx_sdk/abi/bytes_value_test.py
@@ -28,3 +28,6 @@ def test_set_payload_and_get_payload():
     # With errors
     with pytest.raises(TypeError, match="cannot convert 'types.SimpleNamespace' object to bytes"):
         BytesValue().set_payload(SimpleNamespace(a=1, b=2, c=3))
+
+    with pytest.raises(ValueError, match="cannot get value from dictionary"):
+        BytesValue().set_payload({})

--- a/multiversx_sdk/abi/bytes_value_test.py
+++ b/multiversx_sdk/abi/bytes_value_test.py
@@ -16,6 +16,15 @@ def test_set_payload_and_get_payload():
     value.set_payload(b"hello")
     assert value.get_payload() == b"hello"
 
+    # From dictionary
+    value = BytesValue()
+    value.set_payload(
+        {
+            "hex": "68656c6c6f"
+        }
+    )
+    assert value.get_payload() == b"hello"
+
     # With errors
     with pytest.raises(TypeError, match="cannot convert 'types.SimpleNamespace' object to bytes"):
         BytesValue().set_payload(SimpleNamespace(a=1, b=2, c=3))

--- a/multiversx_sdk/abi/bytes_value_test.py
+++ b/multiversx_sdk/abi/bytes_value_test.py
@@ -29,5 +29,5 @@ def test_set_payload_and_get_payload():
     with pytest.raises(TypeError, match="cannot convert 'types.SimpleNamespace' object to bytes"):
         BytesValue().set_payload(SimpleNamespace(a=1, b=2, c=3))
 
-    with pytest.raises(ValueError, match="cannot get value from dictionary"):
+    with pytest.raises(ValueError, match="cannot get value from dictionary: missing 'hex' key"):
         BytesValue().set_payload({})

--- a/multiversx_sdk/abi/shared.py
+++ b/multiversx_sdk/abi/shared.py
@@ -45,6 +45,9 @@ def convert_native_value_to_dictionary(obj: Any, raise_on_failure: bool = True) 
 
 
 def convert_native_value_to_list(obj: Any, raise_on_failure: bool = True) -> Tuple[List[Any], bool]:
+    if isinstance(obj, dict):
+        raise ValueError("cannot properly convert dictionary to list")
+
     try:
         return list(obj), True
     except Exception as error:

--- a/multiversx_sdk/abi/shared_test.py
+++ b/multiversx_sdk/abi/shared_test.py
@@ -42,6 +42,15 @@ def test_convert_native_value_to_list():
     assert not ok
 
     # With errors (raise on failure)
+    with pytest.raises(ValueError, match="cannot properly convert dictionary to list"):
+        items, ok = convert_native_value_to_list(
+            {
+                "a": 1,
+                "b": 2,
+                "c": 3
+            }
+        )
+
     with pytest.raises(ValueError, match="cannot convert native value to list"):
         items, ok = convert_native_value_to_list(42)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "multiversx-sdk"
-version = "0.10.0"
+version = "0.10.1"
 authors = [
   { name="MultiversX" },
 ]


### PR DESCRIPTION
Previously, the `AddresValue` used to convert the value of `set_payload` to `bytes`. Added support to set payload from a `dictionary` like bellow:
```py
AddressValue.set_payload(
    {
         "bech32": "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
    }
)
```
or
```py
AddressValue.set_payload(
    {
         "hex": "0139472eff6886771a982f3083da5d421f24c29181e63888228dc81ca60d69e1"
    }
)
```

`BytesValue` can now be set from a `hex` string, like so:
```py
BytesValue.set_payload(
    {
         "hex": "68656c6c6f"
    }
)
```

Also now, an error is raised if someone tries to convert a `dictionary` to a `list` using `convert_native_value_to_list`.