### PR TITLE
Minor breaking change: pass "Token" & "TokenTransfer" as concrete classes, instead as of interfaces

### DIFF
--- a/multiversx_sdk/core/interfaces.py
+++ b/multiversx_sdk/core/interfaces.py
@@ -40,25 +40,6 @@ class IMessage(Protocol):
     signer: str
 
 
-class IToken(Protocol):
-    identifier: str
-    nonce: int
-
-
-class ITokenTransfer(Protocol):
-    @property
-    def token(self) -> IToken:
-        ...
-
-    amount: int
-
-
-class ITokenIdentifierParts(Protocol):
-    ticker: str
-    random_sequence: str
-    nonce: int
-
-
 INonce = int
 IGasPrice = int
 IGasLimit = int

--- a/multiversx_sdk/core/tokens.py
+++ b/multiversx_sdk/core/tokens.py
@@ -6,7 +6,6 @@ from multiversx_sdk.core.constants import (
     EGLD_IDENTIFIER_FOR_MULTI_ESDTNFT_TRANSFER, TOKEN_RANDOM_SEQUENCE_LENGTH)
 from multiversx_sdk.core.errors import (BadUsageError,
                                         InvalidTokenIdentifierError)
-from multiversx_sdk.core.interfaces import IToken, ITokenIdentifierParts
 
 
 class Token:
@@ -16,7 +15,7 @@ class Token:
 
 
 class TokenTransfer:
-    def __init__(self, token: IToken, amount: int) -> None:
+    def __init__(self, token: Token, amount: int) -> None:
         """`amount` should always be in atomic units: 1.000000 "USDC-c76f1f" = "1000000"""
         self.token = token
         self.amount = amount
@@ -38,7 +37,7 @@ class TokenComputer:
     def __init__(self) -> None:
         pass
 
-    def is_fungible(self, token: IToken) -> bool:
+    def is_fungible(self, token: Token) -> bool:
         return token.nonce == 0
 
     def extract_nonce_from_extended_identifier(self, identifier: str) -> int:
@@ -95,7 +94,7 @@ class TokenComputer:
         nonce_hex = encode_unsigned_number(nonce).hex()
         return identifier + "-" + nonce_hex
 
-    def compute_extended_identifier_from_parts(self, parts: ITokenIdentifierParts) -> str:
+    def compute_extended_identifier_from_parts(self, parts: TokenIdentifierParts) -> str:
         identifier = parts.ticker + "-" + parts.random_sequence
         return self.compute_extended_identifier_from_identifier_and_nonce(identifier, parts.nonce)
 

--- a/multiversx_sdk/core/transactions_factories/smart_contract_transactions_factory.py
+++ b/multiversx_sdk/core/transactions_factories/smart_contract_transactions_factory.py
@@ -8,7 +8,7 @@ from multiversx_sdk.core.code_metadata import CodeMetadata
 from multiversx_sdk.core.constants import (ARGS_SEPARATOR,
                                            CONTRACT_DEPLOY_ADDRESS,
                                            VM_TYPE_WASM_VM)
-from multiversx_sdk.core.interfaces import IAddress, ITokenTransfer
+from multiversx_sdk.core.interfaces import IAddress
 from multiversx_sdk.core.serializer import arg_to_string, args_to_buffers
 from multiversx_sdk.core.tokens import TokenComputer, TokenTransfer
 from multiversx_sdk.core.transaction import Transaction
@@ -86,7 +86,7 @@ class SmartContractTransactionsFactory:
                                        gas_limit: int,
                                        arguments: Sequence[Any] = [],
                                        native_transfer_amount: int = 0,
-                                       token_transfers: Sequence[ITokenTransfer] = []) -> Transaction:
+                                       token_transfers: List[TokenTransfer] = []) -> Transaction:
         number_of_tokens = len(token_transfers)
         receiver = contract
 

--- a/multiversx_sdk/core/transactions_factories/token_transfers_data_builder.py
+++ b/multiversx_sdk/core/transactions_factories/token_transfers_data_builder.py
@@ -1,7 +1,8 @@
-from typing import List, Protocol, Sequence
+from typing import List, Protocol
 
-from multiversx_sdk.core.interfaces import IAddress, ITokenTransfer
+from multiversx_sdk.core.interfaces import IAddress
 from multiversx_sdk.core.serializer import arg_to_string, args_to_strings
+from multiversx_sdk.core.tokens import TokenTransfer
 
 
 class ITokenComputer(Protocol):
@@ -13,13 +14,13 @@ class TokenTransfersDataBuilder:
     def __init__(self, token_computer: ITokenComputer) -> None:
         self.token_computer = token_computer
 
-    def build_args_for_esdt_transfer(self, transfer: ITokenTransfer) -> List[str]:
+    def build_args_for_esdt_transfer(self, transfer: TokenTransfer) -> List[str]:
         args = ["ESDTTransfer"]
         args.extend(args_to_strings([transfer.token.identifier, transfer.amount]))
 
         return args
 
-    def build_args_for_single_esdt_nft_transfer(self, transfer: ITokenTransfer, receiver: IAddress) -> List[str]:
+    def build_args_for_single_esdt_nft_transfer(self, transfer: TokenTransfer, receiver: IAddress) -> List[str]:
         args = ["ESDTNFTTransfer"]
         token = transfer.token
         identifier = self.token_computer.extract_identifier_from_extended_identifier(token.identifier)
@@ -28,7 +29,7 @@ class TokenTransfersDataBuilder:
 
         return args
 
-    def build_args_for_multi_esdt_nft_transfer(self, receiver: IAddress, transfers: Sequence[ITokenTransfer]) -> List[str]:
+    def build_args_for_multi_esdt_nft_transfer(self, receiver: IAddress, transfers: List[TokenTransfer]) -> List[str]:
         args = ["MultiESDTNFTTransfer", receiver.to_hex(), arg_to_string(len(transfers))]
 
         for transfer in transfers:

--- a/multiversx_sdk/core/transactions_factories/transfer_transactions_factory.py
+++ b/multiversx_sdk/core/transactions_factories/transfer_transactions_factory.py
@@ -1,7 +1,7 @@
 from typing import List, Optional, Protocol, Sequence
 
 from multiversx_sdk.core.errors import BadUsageError
-from multiversx_sdk.core.interfaces import IAddress, ITokenTransfer
+from multiversx_sdk.core.interfaces import IAddress
 from multiversx_sdk.core.tokens import TokenComputer, TokenTransfer
 from multiversx_sdk.core.transaction import Transaction
 from multiversx_sdk.core.transactions_factories.token_transfers_data_builder import \
@@ -47,7 +47,7 @@ class TransferTransactionsFactory:
     def create_transaction_for_esdt_token_transfer(self,
                                                    sender: IAddress,
                                                    receiver: IAddress,
-                                                   token_transfers: Sequence[ITokenTransfer]) -> Transaction:
+                                                   token_transfers: List[TokenTransfer]) -> Transaction:
         data_parts: List[str] = []
         extra_gas_for_transfer = 0
 
@@ -81,7 +81,7 @@ class TransferTransactionsFactory:
                                         sender: IAddress,
                                         receiver: IAddress,
                                         native_amount: Optional[int] = None,
-                                        token_transfers: Optional[Sequence[ITokenTransfer]] = None,
+                                        token_transfers: Optional[List[TokenTransfer]] = None,
                                         data: Optional[bytes] = None) -> Transaction:
         if token_transfers and data:
             raise BadUsageError("Can't set data field when sending esdt tokens")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "multiversx-sdk"
-version = "0.12.0"
+version = "0.13.0"
 authors = [
   { name="MultiversX" },
 ]


### PR DESCRIPTION
 - Refactoring: Pass `Token` & `TokenTransfer` as concrete classes (since they are mere DTOs), instead as of an interface
 - `IToken`, `ITokenTransfer` and `ITokenIdentifierParts` have been removed - this is a small breaking change of the public API
 - Related to https://github.com/multiversx/mx-sdk-specs/pull/76.