### PR TITLE
Renamed method parameter and fixed linter issue

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-ignore = E501, E722
+extend-ignore = E501, E722

--- a/multiversx_sdk/abi/abi.py
+++ b/multiversx_sdk/abi/abi.py
@@ -23,7 +23,9 @@ from multiversx_sdk.abi.multi_value import MultiValue
 from multiversx_sdk.abi.option_value import OptionValue
 from multiversx_sdk.abi.optional_value import OptionalValue
 from multiversx_sdk.abi.serializer import Serializer
-from multiversx_sdk.abi.small_int_values import *
+from multiversx_sdk.abi.small_int_values import (I8Value, I16Value, I32Value,
+                                                 I64Value, U8Value, U16Value,
+                                                 U32Value, U64Value)
 from multiversx_sdk.abi.string_value import StringValue
 from multiversx_sdk.abi.struct_value import StructValue
 from multiversx_sdk.abi.token_identifier_value import TokenIdentifierValue
@@ -189,7 +191,7 @@ class Abi:
         output_native_values = [value.get_payload() for value in output_values_as_native_object_holders]
         return output_native_values
 
-    def decode_event(self, event_name: str, topics: List[bytes], data_items: List[bytes]) -> SimpleNamespace:
+    def decode_event(self, event_name: str, topics: List[bytes], additional_data: List[bytes]) -> SimpleNamespace:
         result = SimpleNamespace()
         event_definition = self.definition.get_event_definition(event_name)
         event_prototype = self._get_event_prototype(event_name)
@@ -212,7 +214,7 @@ class Abi:
         non_indexed_inputs_names = [item.name for item in non_indexed_inputs]
 
         output_values = [field.value for field in fields if field.name in non_indexed_inputs_names]
-        self._serializer.deserialize_parts(data_items, output_values)
+        self._serializer.deserialize_parts(additional_data, output_values)
 
         output_values_as_native_object_holders = cast(List[IPayloadHolder], output_values)
         output_native_values = [value.get_payload() for value in output_values_as_native_object_holders]
@@ -265,6 +267,8 @@ class Abi:
             return I16Value()
         if name == "i32":
             return I32Value()
+        if name == "i64":
+            return I64Value()
         if name == "BigUint":
             return BigUIntValue()
         if name == "BigInt":

--- a/multiversx_sdk/abi/serializer_test.py
+++ b/multiversx_sdk/abi/serializer_test.py
@@ -7,13 +7,14 @@ from multiversx_sdk.abi.biguint_value import BigUIntValue
 from multiversx_sdk.abi.bytes_value import BytesValue
 from multiversx_sdk.abi.counted_variadic_values import CountedVariadicValues
 from multiversx_sdk.abi.enum_value import EnumValue
-from multiversx_sdk.abi.fields import *
+from multiversx_sdk.abi.fields import Field
 from multiversx_sdk.abi.list_value import ListValue
-from multiversx_sdk.abi.multi_value import *
+from multiversx_sdk.abi.multi_value import MultiValue
 from multiversx_sdk.abi.option_value import OptionValue
 from multiversx_sdk.abi.optional_value import OptionalValue
 from multiversx_sdk.abi.serializer import Serializer
-from multiversx_sdk.abi.small_int_values import *
+from multiversx_sdk.abi.small_int_values import (U8Value, U16Value, U32Value,
+                                                 U64Value)
 from multiversx_sdk.abi.string_value import StringValue
 from multiversx_sdk.abi.struct_value import StructValue
 from multiversx_sdk.abi.variadic_values import VariadicValues
@@ -501,7 +502,7 @@ def test_real_world_multisig_get_pending_action_full_info():
         item_creator=lambda: BytesValue()
     )
 
-    def action_fields_provider(discriminant: int) -> List[Field]:
+    def action_fields_provider(discriminant: int) -> list[Field]:
         if discriminant == 5:
             return [
                 Field("to", action_to),

--- a/multiversx_sdk/core/transaction_test.py
+++ b/multiversx_sdk/core/transaction_test.py
@@ -317,8 +317,8 @@ class TestTransaction:
             signature=tx.signature
         )
 
-        assert is_signed_by_alice == True
-        assert is_signed_by_bob == False
+        assert is_signed_by_alice
+        assert is_signed_by_bob is False
 
     def test_compute_bytes_for_verifying_transaction_signed_by_hash(self):
         tx = Transaction(
@@ -343,5 +343,5 @@ class TestTransaction:
             signature=tx.signature
         )
 
-        assert is_signed_by_alice == True
-        assert is_signed_by_bob == False
+        assert is_signed_by_alice
+        assert is_signed_by_bob is False

--- a/multiversx_sdk/core/transactions_factories/transfer_transactions_factory.py
+++ b/multiversx_sdk/core/transactions_factories/transfer_transactions_factory.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Protocol, Sequence
+from typing import List, Optional, Protocol
 
 from multiversx_sdk.core.errors import BadUsageError
 from multiversx_sdk.core.interfaces import IAddress

--- a/multiversx_sdk/core/transactions_outcome_parsers/transaction_events_parser.py
+++ b/multiversx_sdk/core/transactions_outcome_parsers/transaction_events_parser.py
@@ -5,7 +5,7 @@ from multiversx_sdk.core.transaction_on_network import TransactionEvent
 
 
 class IAbi(Protocol):
-    def decode_event(self, event_name: str, topics: List[bytes], data_items: List[bytes]) -> SimpleNamespace:
+    def decode_event(self, event_name: str, topics: List[bytes], additional_data: List[bytes]) -> SimpleNamespace:
         ...
 
 
@@ -30,5 +30,5 @@ class TransactionEventsParser:
         return self.abi.decode_event(
             event_name=abi_identifier,
             topics=topics,
-            data_items=event.additional_data,
+            additional_data=event.additional_data,
         )

--- a/multiversx_sdk/core/typecheck.py
+++ b/multiversx_sdk/core/typecheck.py
@@ -1,5 +1,5 @@
 """
-Runtime type-checking is not a good idea, generally speaking. 
+Runtime type-checking is not a good idea, generally speaking.
 However, some developers may inadvertently disable static type-checking in their IDEs,
 and this can lead to hard-to-debug errors.
 

--- a/multiversx_sdk/network_providers/network_config.py
+++ b/multiversx_sdk/network_providers/network_config.py
@@ -34,7 +34,7 @@ class NetworkConfig:
         network_config.num_shards_without_meta = int(payload.get('erd_num_shards_without_meta', 0))
 
         return network_config
-    
+
     def to_dictionary(self) -> Dict[str, Any]:
         return {
             "chainId": self.chain_id,

--- a/multiversx_sdk/network_providers/transaction_decoder.py
+++ b/multiversx_sdk/network_providers/transaction_decoder.py
@@ -10,8 +10,14 @@ DEFAULT_HRP = "erd"
 
 
 class ITransactionToDecode(Protocol):
-    sender: IAddress
-    receiver: IAddress
+    @property
+    def sender(self) -> IAddress:
+        ...
+
+    @property
+    def receiver(self) -> IAddress:
+        ...
+
     data: str
     value: int
 

--- a/multiversx_sdk/wallet/libraries/bls_facade_test.py
+++ b/multiversx_sdk/wallet/libraries/bls_facade_test.py
@@ -43,7 +43,7 @@ def test_verify_message_signature():
         signature=bytes.fromhex("84fd0a3a9d4f1ea2d4b40c6da67f9b786284a1c3895b7253fec7311597cda3f757862bb0690a92a13ce612c33889fd86")
     )
 
-    assert ok == True
+    assert ok
 
     # With altered signature
     ok = facade.verify_message_signature(
@@ -59,7 +59,7 @@ def test_verify_message_signature():
         signature=bytes.fromhex("84fd0a3a9d4f1ea2d4b40c6da67f9b786284a1c3895b7253fec7311597cda3f757862bb0690a92a13ce612c33889fd86")
     )
 
-    assert ok == False
+    assert not ok
 
     # With bad public key
     ok = facade.verify_message_signature(
@@ -68,7 +68,7 @@ def test_verify_message_signature():
         signature=bytes.fromhex("84fd0a3a9d4f1ea2d4b40c6da67f9b786284a1c3895b7253fec7311597cda3f757862bb0690a92a13ce612c33889fd86")
     )
 
-    assert ok == False
+    assert not ok
 
 
 def test_generate_sign_and_verify():
@@ -80,4 +80,4 @@ def test_generate_sign_and_verify():
     signature = facade.compute_message_signature(message, private_key)
     ok = facade.verify_message_signature(public_key, message, signature)
 
-    assert ok == True
+    assert ok

--- a/multiversx_sdk/wallet/validator_test.py
+++ b/multiversx_sdk/wallet/validator_test.py
@@ -26,10 +26,10 @@ def test_verify_message():
     message = b"hello"
     signature = bytes.fromhex("84fd0a3a9d4f1ea2d4b40c6da67f9b786284a1c3895b7253fec7311597cda3f757862bb0690a92a13ce612c33889fd86")
 
-    assert verifier.verify(message, signature) == True
+    assert verifier.verify(message, signature)
 
     invalid_signature = bytes.fromhex("94fd0a3a9d4f1ea2d4b40c6da67f9b786284a1c3895b7253fec7311597cda3f757862bb0690a92a13ce612c33889fd86")
-    assert verifier.verify(message, invalid_signature) == False
+    assert verifier.verify(message, invalid_signature) is False
 
 
 def test_pem_save():


### PR DESCRIPTION
Renamed a parameter:
From: 
```py
def decode_event(self, event_name: str, topics: List[bytes], data_items: List[bytes]) -> SimpleNamespace:
```
To:
```py
def decode_event(self, event_name: str, topics: List[bytes], additional_data: List[bytes]) -> SimpleNamespace:
```