### PR TITLE
ABI: handle CodeMetadataValue

### DIFF
--- a/multiversx_sdk/abi/__init__.py
+++ b/multiversx_sdk/abi/__init__.py
@@ -6,6 +6,7 @@ from multiversx_sdk.abi.bigint_value import BigIntValue
 from multiversx_sdk.abi.biguint_value import BigUIntValue
 from multiversx_sdk.abi.bool_value import BoolValue
 from multiversx_sdk.abi.bytes_value import BytesValue
+from multiversx_sdk.abi.code_metadata_value import CodeMetadataValue
 from multiversx_sdk.abi.enum_value import EnumValue
 from multiversx_sdk.abi.fields import Field
 from multiversx_sdk.abi.list_value import ListValue
@@ -32,6 +33,7 @@ __all__ = [
     "BigUIntValue",
     "BoolValue",
     "BytesValue",
+    "CodeMetadataValue",
     "EnumValue",
     "Field",
     "ListValue",

--- a/multiversx_sdk/abi/abi.py
+++ b/multiversx_sdk/abi/abi.py
@@ -14,6 +14,7 @@ from multiversx_sdk.abi.array_value import ArrayValue
 from multiversx_sdk.abi.biguint_value import BigUIntValue
 from multiversx_sdk.abi.bool_value import BoolValue
 from multiversx_sdk.abi.bytes_value import BytesValue
+from multiversx_sdk.abi.code_metadata_value import CodeMetadataValue
 from multiversx_sdk.abi.counted_variadic_values import CountedVariadicValues
 from multiversx_sdk.abi.enum_value import EnumValue
 from multiversx_sdk.abi.fields import Field
@@ -282,7 +283,7 @@ class Abi:
         if name == "EgldOrEsdtTokenIdentifier":
             return TokenIdentifierValue()
         if name == "CodeMetadata":
-            return BytesValue()
+            return CodeMetadataValue()
         if name == "tuple":
             return TupleValue([self._create_prototype(type_parameter) for type_parameter in type_formula.type_parameters])
         if name == "Option":

--- a/multiversx_sdk/abi/code_metadata_value.py
+++ b/multiversx_sdk/abi/code_metadata_value.py
@@ -1,0 +1,46 @@
+import io
+from typing import Any
+
+from multiversx_sdk.abi.shared import read_bytes_exactly
+from multiversx_sdk.core.code_metadata import (CODE_METADATA_LENGTH,
+                                               CodeMetadata)
+
+
+class CodeMetadataValue:
+    def __init__(self, value: bytes = b"") -> None:
+        self.value = value
+
+    @classmethod
+    def from_code_metadata(cls, code_metadata: CodeMetadata) -> "CodeMetadataValue":
+        return cls(code_metadata.serialize())
+
+    def encode_nested(self, writer: io.BytesIO):
+        writer.write(self.value)
+
+    def encode_top_level(self, writer: io.BytesIO):
+        writer.write(self.value)
+
+    def decode_nested(self, reader: io.BytesIO):
+        length = CODE_METADATA_LENGTH
+        data = read_bytes_exactly(reader, length)
+        self.value = data
+
+    def decode_top_level(self, data: bytes):
+        self.value = data
+
+    def set_payload(self, value: Any):
+        if isinstance(value, bytes):
+            self.value = CodeMetadata.from_bytes(value).serialize()
+        elif isinstance(value, CodeMetadata):
+            self.value = value.serialize()
+        else:
+            raise ValueError(f"cannot set payload for code metadata (should be either a CodeMetadata or bytes, but got: {type(value)})")
+
+    def get_payload(self) -> Any:
+        return self.value
+
+    def __eq__(self, other: Any) -> bool:
+        return isinstance(other, CodeMetadataValue) and self.value == other.value
+
+    def __bytes__(self) -> bytes:
+        return self.value

--- a/multiversx_sdk/abi/code_metadata_value.py
+++ b/multiversx_sdk/abi/code_metadata_value.py
@@ -30,7 +30,7 @@ class CodeMetadataValue:
 
     def set_payload(self, value: Any):
         if isinstance(value, bytes):
-            self.value = CodeMetadata.from_bytes(value).serialize()
+            self.value = CodeMetadata.new_from_bytes(value).serialize()
         elif isinstance(value, CodeMetadata):
             self.value = value.serialize()
         else:

--- a/multiversx_sdk/abi/code_metadata_value.py
+++ b/multiversx_sdk/abi/code_metadata_value.py
@@ -11,7 +11,7 @@ class CodeMetadataValue:
         self.value = value
 
     @classmethod
-    def from_code_metadata(cls, code_metadata: CodeMetadata) -> "CodeMetadataValue":
+    def new_from_code_metadata(cls, code_metadata: CodeMetadata) -> "CodeMetadataValue":
         return cls(code_metadata.serialize())
 
     def encode_nested(self, writer: io.BytesIO):

--- a/multiversx_sdk/abi/code_metadata_value_test.py
+++ b/multiversx_sdk/abi/code_metadata_value_test.py
@@ -1,0 +1,25 @@
+import re
+
+import pytest
+
+from multiversx_sdk.abi.code_metadata_value import CodeMetadataValue
+from multiversx_sdk.core.code_metadata import CodeMetadata
+
+
+def test_set_payload_and_get_payload():
+    # Simple
+    value = CodeMetadataValue()
+    value.set_payload(bytes([0x05, 0x00]))
+    assert value.get_payload() == bytes([0x05, 0x00])
+
+    # From CodeMetadata
+    value = CodeMetadataValue()
+    value.set_payload(CodeMetadata(upgradeable=True, readable=True, payable=True, payable_by_contract=True))
+    assert value.get_payload() == bytes([0x05, 0x06])
+
+    # With errors
+    with pytest.raises(ValueError, match=re.escape("cannot set payload for code metadata (should be either a CodeMetadata or bytes, but got: <class 'dict'>)")):
+        CodeMetadataValue().set_payload({})
+
+    with pytest.raises(ValueError, match="code metadata buffer has length 4, expected 2"):
+        CodeMetadataValue().set_payload(bytes([0, 1, 2, 3]))

--- a/multiversx_sdk/abi/code_metadata_value_test.py
+++ b/multiversx_sdk/abi/code_metadata_value_test.py
@@ -12,7 +12,7 @@ def test_set_payload_and_get_payload():
     value.set_payload(bytes([0x05, 0x00]))
     assert value.get_payload() == bytes([0x05, 0x00])
 
-    # From CodeMetadata
+    # With CodeMetadata
     value = CodeMetadataValue()
     value.set_payload(CodeMetadata(upgradeable=True, readable=True, payable=True, payable_by_contract=True))
     assert value.get_payload() == bytes([0x05, 0x06])

--- a/multiversx_sdk/abi/code_metadata_value_test.py
+++ b/multiversx_sdk/abi/code_metadata_value_test.py
@@ -6,6 +6,14 @@ from multiversx_sdk.abi.code_metadata_value import CodeMetadataValue
 from multiversx_sdk.core.code_metadata import CodeMetadata
 
 
+def test_new_from_code_metadata():
+    value = CodeMetadataValue.new_from_code_metadata(CodeMetadata())
+    assert value.get_payload() == bytes([0x05, 0x00])
+
+    value = CodeMetadataValue.new_from_code_metadata(CodeMetadata(upgradeable=True, readable=True, payable=True, payable_by_contract=True))
+    assert value.get_payload() == bytes([0x05, 0x06])
+
+
 def test_set_payload_and_get_payload():
     # Simple
     value = CodeMetadataValue()

--- a/multiversx_sdk/core/code_metadata.py
+++ b/multiversx_sdk/core/code_metadata.py
@@ -23,7 +23,7 @@ class CodeMetadata:
         self.payable_by_contract = payable_by_contract
 
     @classmethod
-    def from_bytes(cls, data: bytes) -> "CodeMetadata":
+    def new_from_bytes(cls, data: bytes) -> "CodeMetadata":
         if len(data) != CODE_METADATA_LENGTH:
             raise ValueError(f"code metadata buffer has length {len(data)}, expected {CODE_METADATA_LENGTH}")
 

--- a/multiversx_sdk/core/code_metadata.py
+++ b/multiversx_sdk/core/code_metadata.py
@@ -1,5 +1,7 @@
 from enum import Enum
 
+CODE_METADATA_LENGTH = 2
+
 
 class ByteZero(Enum):
     Upgradeable = 1
@@ -19,6 +21,21 @@ class CodeMetadata:
         self.readable = readable
         self.payable = payable
         self.payable_by_contract = payable_by_contract
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> "CodeMetadata":
+        if len(data) != CODE_METADATA_LENGTH:
+            raise ValueError(f"code metadata buffer has length {len(data)}, expected {CODE_METADATA_LENGTH}")
+
+        byte_zero = data[0]
+        byte_one = data[1]
+
+        upgradeable = (byte_zero & ByteZero.Upgradeable.value) != 0
+        readable = (byte_zero & ByteZero.Readable.value) != 0
+        payable = (byte_one & ByteOne.Payable.value) != 0
+        payable_by_contract = (byte_one & ByteOne.PayableByContract.value) != 0
+
+        return cls(upgradeable, readable, payable, payable_by_contract)
 
     def serialize(self) -> bytes:
         data = bytearray([0, 0])

--- a/multiversx_sdk/core/code_metadata_test.py
+++ b/multiversx_sdk/core/code_metadata_test.py
@@ -5,33 +5,33 @@ import pytest
 from multiversx_sdk.core.code_metadata import CodeMetadata
 
 
-def test_code_metadata_from_bytes():
-    metadata = CodeMetadata.from_bytes(bytes([0x05, 0x00]))
+def test_code_metadata_new_from_bytes():
+    metadata = CodeMetadata.new_from_bytes(bytes([0x05, 0x00]))
     assert metadata.upgradeable == True
     assert metadata.readable == True
     assert metadata.payable == False
     assert metadata.payable_by_contract == False
 
-    metadata = CodeMetadata.from_bytes(bytes([0x05, 0x06]))
+    metadata = CodeMetadata.new_from_bytes(bytes([0x05, 0x06]))
     assert metadata.upgradeable == True
     assert metadata.readable == True
     assert metadata.payable == True
     assert metadata.payable_by_contract == True
 
-    metadata = CodeMetadata.from_bytes(bytes([0x05, 0x00]))
+    metadata = CodeMetadata.new_from_bytes(bytes([0x05, 0x00]))
     assert metadata.upgradeable == True
     assert metadata.readable == True
     assert metadata.payable == False
     assert metadata.payable_by_contract == False
 
-    metadata = CodeMetadata.from_bytes(bytes([0x00, 0x00]))
+    metadata = CodeMetadata.new_from_bytes(bytes([0x00, 0x00]))
     assert metadata.upgradeable == False
     assert metadata.readable == False
     assert metadata.payable == False
     assert metadata.payable_by_contract == False
 
     with pytest.raises(ValueError, match="code metadata buffer has length 4, expected 2"):
-        CodeMetadata.from_bytes(bytes([0x00, 0x01, 0x02, 0x03]))
+        CodeMetadata.new_from_bytes(bytes([0x00, 0x01, 0x02, 0x03]))
 
 
 def test_code_metadata_serialize():

--- a/multiversx_sdk/core/code_metadata_test.py
+++ b/multiversx_sdk/core/code_metadata_test.py
@@ -1,6 +1,37 @@
 
 
+import pytest
+
 from multiversx_sdk.core.code_metadata import CodeMetadata
+
+
+def test_code_metadata_from_bytes():
+    metadata = CodeMetadata.from_bytes(bytes([0x05, 0x00]))
+    assert metadata.upgradeable == True
+    assert metadata.readable == True
+    assert metadata.payable == False
+    assert metadata.payable_by_contract == False
+
+    metadata = CodeMetadata.from_bytes(bytes([0x05, 0x06]))
+    assert metadata.upgradeable == True
+    assert metadata.readable == True
+    assert metadata.payable == True
+    assert metadata.payable_by_contract == True
+
+    metadata = CodeMetadata.from_bytes(bytes([0x05, 0x00]))
+    assert metadata.upgradeable == True
+    assert metadata.readable == True
+    assert metadata.payable == False
+    assert metadata.payable_by_contract == False
+
+    metadata = CodeMetadata.from_bytes(bytes([0x00, 0x00]))
+    assert metadata.upgradeable == False
+    assert metadata.readable == False
+    assert metadata.payable == False
+    assert metadata.payable_by_contract == False
+
+    with pytest.raises(ValueError, match="code metadata buffer has length 4, expected 2"):
+        CodeMetadata.from_bytes(bytes([0x00, 0x01, 0x02, 0x03]))
 
 
 def test_code_metadata_serialize():

--- a/multiversx_sdk/core/code_metadata_test.py
+++ b/multiversx_sdk/core/code_metadata_test.py
@@ -18,11 +18,11 @@ def test_code_metadata_new_from_bytes():
     assert metadata.payable == True
     assert metadata.payable_by_contract == True
 
-    metadata = CodeMetadata.new_from_bytes(bytes([0x05, 0x00]))
+    metadata = CodeMetadata.new_from_bytes(bytes([0x05, 0x04]))
     assert metadata.upgradeable == True
     assert metadata.readable == True
     assert metadata.payable == False
-    assert metadata.payable_by_contract == False
+    assert metadata.payable_by_contract == True
 
     metadata = CodeMetadata.new_from_bytes(bytes([0x00, 0x00]))
     assert metadata.upgradeable == False


### PR DESCRIPTION
Previously, `CodeMetadata` was handled as `bytes` - this was incorrect, since the encoding is different (code metadata has a fixed size of two bytes).