### PR TITLE
Move "INetworkProvider" and "IAbi" to controllers/interfaces.py

### DIFF
--- a/multiversx_sdk/controllers/delegation_controller.py
+++ b/multiversx_sdk/controllers/delegation_controller.py
@@ -1,6 +1,6 @@
-from typing import List, Optional, Protocol, Sequence, Union
+from typing import List, Sequence
 
-from multiversx_sdk.controllers.interfaces import IAccount
+from multiversx_sdk.controllers.interfaces import IAccount, INetworkProvider
 from multiversx_sdk.core.interfaces import IAddress, IValidatorPublicKey
 from multiversx_sdk.core.transaction import Transaction
 from multiversx_sdk.core.transaction_computer import TransactionComputer
@@ -9,12 +9,6 @@ from multiversx_sdk.core.transactions_factories import (
     DelegationTransactionsFactory, TransactionsFactoryConfig)
 from multiversx_sdk.core.transactions_outcome_parsers.delegation_transactions_outcome_parser import (
     CreateNewDelegationContractOutcome, DelegationTransactionsOutcomeParser)
-from multiversx_sdk.network_providers.resources import AwaitingOptions
-
-
-class INetworkProvider(Protocol):
-    def await_transaction_completed(self, tx_hash: Union[str, bytes], options: Optional[AwaitingOptions] = None) -> TransactionOnNetwork:
-        ...
 
 
 class DelegationController:

--- a/multiversx_sdk/controllers/interfaces.py
+++ b/multiversx_sdk/controllers/interfaces.py
@@ -1,6 +1,10 @@
-from typing import Protocol
+from typing import Any, List, Optional, Protocol, Union
 
 from multiversx_sdk.core.interfaces import IAddress
+from multiversx_sdk.core.smart_contract_query import (
+    SmartContractQuery, SmartContractQueryResponse)
+from multiversx_sdk.core.transaction_on_network import TransactionOnNetwork
+from multiversx_sdk.network_providers.resources import AwaitingOptions
 
 
 class IAccount(Protocol):
@@ -9,4 +13,26 @@ class IAccount(Protocol):
         ...
 
     def sign(self, data: bytes) -> bytes:
+        ...
+
+
+class INetworkProvider(Protocol):
+    def query_contract(self, query: SmartContractQuery) -> SmartContractQueryResponse:
+        ...
+
+    def await_transaction_completed(self, tx_hash: Union[str, bytes], options: Optional[AwaitingOptions] = None) -> TransactionOnNetwork:
+        ...
+
+
+class IAbi(Protocol):
+    def encode_endpoint_input_parameters(self, endpoint_name: str, values: List[Any]) -> List[bytes]:
+        ...
+
+    def encode_constructor_input_parameters(self, values: List[Any]) -> List[bytes]:
+        ...
+
+    def encode_upgrade_constructor_input_parameters(self, values: List[Any]) -> List[bytes]:
+        ...
+
+    def decode_endpoint_output_parameters(self, endpoint_name: str, encoded_values: List[bytes]) -> List[Any]:
         ...

--- a/multiversx_sdk/controllers/relayed_controller.py
+++ b/multiversx_sdk/controllers/relayed_controller.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from multiversx_sdk.controllers.interfaces import IAccount
 from multiversx_sdk.core.interfaces import ITransaction
 from multiversx_sdk.core.transaction import Transaction
@@ -44,4 +42,3 @@ class RelayedController:
         transaction.signature = sender.sign(self.tx_computer.compute_bytes_for_signing(transaction))
 
         return transaction
-

--- a/multiversx_sdk/controllers/smart_contract_controller.py
+++ b/multiversx_sdk/controllers/smart_contract_controller.py
@@ -1,12 +1,11 @@
 from pathlib import Path
-from typing import Any, List, Optional, Protocol, Sequence, Union
+from typing import Any, List, Optional, Sequence, Union
 
-from multiversx_sdk.controllers.interfaces import IAccount
+from multiversx_sdk.controllers.interfaces import (IAbi, IAccount,
+                                                   INetworkProvider)
 from multiversx_sdk.core.interfaces import IAddress
 from multiversx_sdk.core.smart_contract_queries_controller import \
     SmartContractQueriesController
-from multiversx_sdk.core.smart_contract_query import (
-    SmartContractQuery, SmartContractQueryResponse)
 from multiversx_sdk.core.tokens import TokenTransfer
 from multiversx_sdk.core.transaction import Transaction
 from multiversx_sdk.core.transaction_computer import TransactionComputer
@@ -15,29 +14,6 @@ from multiversx_sdk.core.transactions_factories import (
     SmartContractTransactionsFactory, TransactionsFactoryConfig)
 from multiversx_sdk.core.transactions_outcome_parsers import (
     SmartContractDeployOutcome, SmartContractTransactionsOutcomeParser)
-from multiversx_sdk.network_providers.resources import AwaitingOptions
-
-
-class INetworkProvider(Protocol):
-    def query_contract(self, query: SmartContractQuery) -> SmartContractQueryResponse:
-        ...
-
-    def await_transaction_completed(self, tx_hash: Union[str, bytes], options: Optional[AwaitingOptions] = None) -> TransactionOnNetwork:
-        ...
-
-
-class IAbi(Protocol):
-    def encode_endpoint_input_parameters(self, endpoint_name: str, values: List[Any]) -> List[bytes]:
-        ...
-
-    def encode_constructor_input_parameters(self, values: List[Any]) -> List[bytes]:
-        ...
-
-    def encode_upgrade_constructor_input_parameters(self, values: List[Any]) -> List[bytes]:
-        ...
-
-    def decode_endpoint_output_parameters(self, endpoint_name: str, encoded_values: List[bytes]) -> List[Any]:
-        ...
 
 
 class SmartContractController:

--- a/multiversx_sdk/controllers/token_management_controller.py
+++ b/multiversx_sdk/controllers/token_management_controller.py
@@ -1,6 +1,6 @@
-from typing import List, Optional, Protocol, Union
+from typing import List
 
-from multiversx_sdk.controllers.interfaces import IAccount
+from multiversx_sdk.controllers.interfaces import IAccount, INetworkProvider
 from multiversx_sdk.converters.transactions_converter import \
     TransactionsConverter
 from multiversx_sdk.core.interfaces import IAddress
@@ -16,12 +16,6 @@ from multiversx_sdk.core.transactions_outcome_parsers import (
     RegisterMetaEsdtOutcome, SetSpecialRoleOutcome,
     TokenManagementTransactionsOutcomeParser, UnFreezeOutcome, UnPauseOutcome,
     UpdateAttributesOutcome, WipeOutcome)
-from multiversx_sdk.network_providers.resources import AwaitingOptions
-
-
-class INetworkProvider(Protocol):
-    def await_transaction_completed(self, tx_hash: Union[str, bytes], options: Optional[AwaitingOptions] = None) -> TransactionOnNetwork:
-        ...
 
 
 class TokenManagementController:


### PR DESCRIPTION
Move `INetworkProvider` and `IAbi` to `controllers/interfaces.py`.

Even further, perhaps directly receive `Abi` instead of `IAbi` (to be discussed).