### PR TITLE
Fix for single EGLD transfer as token transfer

### DIFF
--- a/multiversx_sdk/core/transactions_factories/transfer_transactions_factory.py
+++ b/multiversx_sdk/core/transactions_factories/transfer_transactions_factory.py
@@ -1,5 +1,7 @@
-from typing import List, Optional, Protocol, Sequence
+from typing import Optional, Protocol
 
+from multiversx_sdk.core.constants import \
+    EGLD_IDENTIFIER_FOR_MULTI_ESDTNFT_TRANSFER
 from multiversx_sdk.core.errors import BadUsageError
 from multiversx_sdk.core.interfaces import IAddress
 from multiversx_sdk.core.tokens import TokenComputer, TokenTransfer
@@ -47,26 +49,14 @@ class TransferTransactionsFactory:
     def create_transaction_for_esdt_token_transfer(self,
                                                    sender: IAddress,
                                                    receiver: IAddress,
-                                                   token_transfers: List[TokenTransfer]) -> Transaction:
-        data_parts: List[str] = []
-        extra_gas_for_transfer = 0
-
-        if len(token_transfers) == 0:
+                                                   token_transfers: list[TokenTransfer]) -> Transaction:
+        if not token_transfers:
             raise BadUsageError("No token transfer has been provided")
-        elif len(token_transfers) == 1:
-            transfer = token_transfers[0]
 
-            if self.token_computer.is_fungible(transfer.token):
-                data_parts = self._data_args_builder.build_args_for_esdt_transfer(transfer)
-                extra_gas_for_transfer = self.config.gas_limit_esdt_transfer + ADDITIONAL_GAS_FOR_ESDT_TRANSFER
-            else:
-                data_parts = self._data_args_builder.build_args_for_single_esdt_nft_transfer(transfer, receiver)
-                extra_gas_for_transfer = self.config.gas_limit_esdt_nft_transfer + ADDITIONAL_GAS_FOR_ESDT_NFT_TRANSFER
-                receiver = sender
+        if len(token_transfers) == 1:
+            data_parts, extra_gas_for_transfer, receiver = self._single_transfer(sender, receiver, token_transfers[0])
         else:
-            data_parts = self._data_args_builder.build_args_for_multi_esdt_nft_transfer(receiver, token_transfers)
-            extra_gas_for_transfer = self.config.gas_limit_multi_esdt_nft_transfer * len(token_transfers) + ADDITIONAL_GAS_FOR_ESDT_NFT_TRANSFER
-            receiver = sender
+            data_parts, extra_gas_for_transfer, receiver = self._multi_transfer(sender, receiver, token_transfers)
 
         return TransactionBuilder(
             config=self.config,
@@ -77,11 +67,37 @@ class TransferTransactionsFactory:
             add_data_movement_gas=True
         ).build()
 
+    def _single_transfer(self,
+                         sender: IAddress,
+                         receiver: IAddress,
+                         transfer: TokenTransfer) -> tuple[list[str], int, IAddress]:
+        if self.token_computer.is_fungible(transfer.token):
+            if transfer.token.identifier == EGLD_IDENTIFIER_FOR_MULTI_ESDTNFT_TRANSFER:
+                data_parts = self._data_args_builder.build_args_for_multi_esdt_nft_transfer(receiver, [transfer])
+                gas = self.config.gas_limit_multi_esdt_nft_transfer + ADDITIONAL_GAS_FOR_ESDT_NFT_TRANSFER
+                return data_parts, gas, sender
+            else:
+                data_parts = self._data_args_builder.build_args_for_esdt_transfer(transfer)
+                gas = self.config.gas_limit_esdt_transfer + ADDITIONAL_GAS_FOR_ESDT_TRANSFER
+                return data_parts, gas, receiver
+
+        data_parts = self._data_args_builder.build_args_for_single_esdt_nft_transfer(transfer, receiver)
+        gas = self.config.gas_limit_esdt_nft_transfer + ADDITIONAL_GAS_FOR_ESDT_NFT_TRANSFER
+        return data_parts, gas, sender
+
+    def _multi_transfer(self,
+                        sender: IAddress,
+                        receiver: IAddress,
+                        token_transfers: list[TokenTransfer]) -> tuple[list[str], int, IAddress]:
+        data_parts = self._data_args_builder.build_args_for_multi_esdt_nft_transfer(receiver, token_transfers)
+        gas = self.config.gas_limit_multi_esdt_nft_transfer * len(token_transfers) + ADDITIONAL_GAS_FOR_ESDT_NFT_TRANSFER
+        return data_parts, gas, sender
+
     def create_transaction_for_transfer(self,
                                         sender: IAddress,
                                         receiver: IAddress,
                                         native_amount: Optional[int] = None,
-                                        token_transfers: Optional[List[TokenTransfer]] = None,
+                                        token_transfers: Optional[list[TokenTransfer]] = None,
                                         data: Optional[bytes] = None) -> Transaction:
         if token_transfers and data:
             raise BadUsageError("Can't set data field when sending esdt tokens")

--- a/multiversx_sdk/core/transactions_factories/transfer_transactions_factory_test.py
+++ b/multiversx_sdk/core/transactions_factories/transfer_transactions_factory_test.py
@@ -176,3 +176,20 @@ class TestTransferTransactionsFactory:
         assert transaction.chain_id == "D"
         assert transaction.data.decode() == "MultiESDTNFTTransfer@8049d639e5a6980d1cd2392abcce41029cda74a1563523a202f09641cc2618f8@03@4e46542d313233343536@0a@01@544553542d393837363534@01@01@45474c442d303030303030@@0de0b6b3a7640000"
         assert transaction.gas_limit == 1_727_500
+
+    def test_egld_as_single_token_transfer(self):
+        egld = Token("EGLD-000000")
+        transfer = TokenTransfer(egld, 1000000000000000000)
+
+        transaction = self.transfer_factory.create_transaction_for_transfer(
+            sender=self.alice,
+            receiver=self.bob,
+            token_transfers=[transfer]
+        )
+
+        assert transaction.sender == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
+        assert transaction.receiver == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
+        assert transaction.value == 0
+        assert transaction.chain_id == "D"
+        assert transaction.data.decode() == "MultiESDTNFTTransfer@8049d639e5a6980d1cd2392abcce41029cda74a1563523a202f09641cc2618f8@01@45474c442d303030303030@@0de0b6b3a7640000"
+        assert transaction.gas_limit == 1_243_500

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "multiversx-sdk"
-version = "0.16.0"
+version = "0.16.1"
 authors = [
   { name="MultiversX" },
 ]


### PR DESCRIPTION
Previously, if a single  `EGLD` token transfer was provided, the `ESDTTransfer` builtin function was used and the transaction would fail, as this operation is not allowed. `EGLD` can only be transferred using the `MultiESDTNFTTransfer` builtin function.