### PR TITLE
Allow bech32 address value payload

### DIFF
--- a/multiversx_sdk/abi/address_value.py
+++ b/multiversx_sdk/abi/address_value.py
@@ -45,6 +45,9 @@ class AddressValue:
         if isinstance(value, dict):
             value = cast(Dict[str, str], value)
             pubkey = self._extract_pubkey_from_dict(value)
+        elif isinstance(value, str):
+            address = Address.new_from_bech32(value)
+            pubkey = address.pubkey
         else:
             pubkey = bytes(value)
 

--- a/multiversx_sdk/abi/address_value.py
+++ b/multiversx_sdk/abi/address_value.py
@@ -47,7 +47,7 @@ class AddressValue:
             pubkey = self._extract_pubkey_from_dict(value)
         elif isinstance(value, str):
             address = Address.new_from_bech32(value)
-            pubkey = address.pubkey
+            pubkey = address.get_public_key()
         else:
             pubkey = bytes(value)
 

--- a/multiversx_sdk/abi/address_value_test.py
+++ b/multiversx_sdk/abi/address_value_test.py
@@ -20,6 +20,12 @@ def test_set_payload_and_get_payload():
     value.set_payload(address)
     assert value.get_payload() == address.get_public_key()
 
+    # Simple (from bech32)
+    address = Address.new_from_bech32("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th")
+    value = AddressValue()
+    value.set_payload(address.bech32())
+    assert value.get_payload() == address.get_public_key()
+
     # From dict using a bech32 address
     address = Address.new_from_bech32("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th")
     value = AddressValue()

--- a/multiversx_sdk/abi/address_value_test.py
+++ b/multiversx_sdk/abi/address_value_test.py
@@ -23,7 +23,7 @@ def test_set_payload_and_get_payload():
     # Simple (from bech32)
     address = Address.new_from_bech32("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th")
     value = AddressValue()
-    value.set_payload(address.bech32())
+    value.set_payload(address.to_bech32())
     assert value.get_payload() == address.get_public_key()
 
     # From dict using a bech32 address


### PR DESCRIPTION
# Context

Currently, bech32 string cannot be directly passed as tranaction argument to the smart-contract factories. Indeed, this leads to an error when setting the payload of an AddressValue

```python
AddressValue().set_payload("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th")

    def set_payload(self, value: Any):
        if isinstance(value, dict):
            value = cast(Dict[str, str], value)
            pubkey = self._extract_pubkey_from_dict(value)
        else:
>           pubkey = bytes(value)
E           TypeError: string argument without an encoding

multiversx_sdk/abi/address_value.py:52: TypeError
```

# Proposed Change

If the `set_payload` method receives a string, it should try to parse it as bech32 to extract the pubkey

```python
def set_payload(self, value: Any):
        if isinstance(value, dict):
            value = cast(Dict[str, str], value)
            pubkey = self._extract_pubkey_from_dict(value)
        elif isinstance(value, str):
            address = Address.new_from_bech32(value)
            pubkey = address.pubkey
        else:
            pubkey = bytes(value)
```

This would allow to pass effectively bech32 strings as transaction arguments to the smart-contract factories.