### PR TITLE
Fix optional dependency import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Store Pull Request comment to be posted
         if: matrix.os == 'ubuntu-latest' && steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'  # Run only on Ubuntu
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: python-coverage-comment-action
           path: python-coverage-comment-action.txt

--- a/multiversx_sdk/ledger/ledger_app.py
+++ b/multiversx_sdk/ledger/ledger_app.py
@@ -1,7 +1,5 @@
 from enum import Enum
 
-from ledgercomm import Transport
-
 from multiversx_sdk.ledger.config import LedgerAppConfiguration
 from multiversx_sdk.ledger.errors import LedgerError
 
@@ -30,14 +28,20 @@ class Apdu:
 class LedgerApp:
     def __init__(self) -> None:
         try:
+            from ledgercomm import Transport
+        except ImportError as e:
+            raise ImportError(
+                "The ledgercomm package is not installed. Please install it using "
+                "pip install multiversx_sdk[ledger]."
+            ) from e
+
+        try:
             self.transport = Transport(interface="hid", debug=False)  # Nano S/X using HID interface
         except Exception:
             raise LedgerError(CONNECTION_ERROR_MSG)
 
     def set_address(self, address_index: int = 0):
-        data = DEFAULT_ACCOUNT_INDEX.to_bytes(4, byteorder="big") + address_index.to_bytes(
-            4, byteorder="big"
-        )
+        data = DEFAULT_ACCOUNT_INDEX.to_bytes(4, byteorder="big") + address_index.to_bytes(4, byteorder="big")
         self.transport.send(cla=0xED, ins=0x05, p1=0x00, p2=0x00, cdata=data)
         sw, _ = self.transport.recv()
         err = get_error(sw)
@@ -45,9 +49,7 @@ class LedgerApp:
             raise LedgerError(err)
 
     def get_address(self, address_index: int = 0) -> str:
-        data = DEFAULT_ACCOUNT_INDEX.to_bytes(4, byteorder="big") + address_index.to_bytes(
-            4, byteorder="big"
-        )
+        data = DEFAULT_ACCOUNT_INDEX.to_bytes(4, byteorder="big") + address_index.to_bytes(4, byteorder="big")
 
         self.transport.send(cla=0xED, ins=0x03, p1=0x00, p2=0x00, cdata=data)
         sw, response = self.transport.recv()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "multiversx-sdk"
-version = "1.0.0b0"
+version = "1.0.0b1"
 authors = [
   { name="MultiversX" },
 ]


### PR DESCRIPTION
Now, when the package is installed without the optional dependency it displays an error message when used:

```py
 ImportError: The ledgercomm package is not installed. Please install it using pip install multiversx_sdk[ledger].
```

Also updated the upload artifact to **v4** according to this [blog post](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/).
