### PR TITLE
Fix wrong bigint prototype

### DIFF
--- a/multiversx_sdk/abi/abi.py
+++ b/multiversx_sdk/abi/abi.py
@@ -14,6 +14,7 @@ from multiversx_sdk.abi.abi_definition import (
 )
 from multiversx_sdk.abi.address_value import AddressValue
 from multiversx_sdk.abi.array_value import ArrayValue
+from multiversx_sdk.abi.bigint_value import BigIntValue
 from multiversx_sdk.abi.biguint_value import BigUIntValue
 from multiversx_sdk.abi.bool_value import BoolValue
 from multiversx_sdk.abi.bytes_value import BytesValue
@@ -298,7 +299,7 @@ class Abi:
         if name == "BigUint":
             return BigUIntValue()
         if name == "BigInt":
-            return BigUIntValue()
+            return BigIntValue()
         if name == "bytes":
             return BytesValue()
         if name == "utf-8 string":

--- a/multiversx_sdk/abi/abi_test.py
+++ b/multiversx_sdk/abi/abi_test.py
@@ -6,6 +6,7 @@ from typing import Optional
 from multiversx_sdk.abi.abi import Abi
 from multiversx_sdk.abi.abi_definition import AbiDefinition, ParameterDefinition
 from multiversx_sdk.abi.address_value import AddressValue
+from multiversx_sdk.abi.bigint_value import BigIntValue
 from multiversx_sdk.abi.biguint_value import BigUIntValue
 from multiversx_sdk.abi.bytes_value import BytesValue
 from multiversx_sdk.abi.counted_variadic_values import CountedVariadicValues
@@ -72,6 +73,9 @@ def test_abi_artificial():
 
     assert len(abi.definition.events) == 1
     assert abi.events_prototypes_by_name["firstEvent"].fields[0].value == BigUIntValue()
+
+    assert abi.endpoints_prototypes_by_name["black"].input_parameters == [BigIntValue()]
+    assert abi.endpoints_prototypes_by_name["black"].output_parameters == []
 
 
 def test_load_abi_with_counted_variadic():

--- a/multiversx_sdk/testutils/testdata/artificial.abi.json
+++ b/multiversx_sdk/testutils/testdata/artificial.abi.json
@@ -74,6 +74,17 @@
                 }
             ],
             "outputs": []
+        },
+        {
+            "name": "black",
+            "mutability": "mutable",
+            "inputs": [
+                {
+                    "name": "a",
+                    "type": "BigInt"
+                }
+            ],
+            "outputs": []
         }
     ],
     "types": {
@@ -81,7 +92,9 @@
             "type": "explicit-enum",
             "variants": [
                 {
-                    "docs": ["indicates that operation was completed"],
+                    "docs": [
+                        "indicates that operation was completed"
+                    ],
                     "name": "completed"
                 },
                 {


### PR DESCRIPTION
# Context

BigInt prototypes were wrongly constructed as `BigUIntValue`

# Proposed Change

Replace `BigUIntValue` by `BigIntValue` and add tests to cover this case