### PR TITLE
Add name in enum payload

### DIFF
--- a/multiversx_sdk/abi/abi_test.py
+++ b/multiversx_sdk/abi/abi_test.py
@@ -474,6 +474,7 @@ def test_decode_custom_enum():
         ),
     )
     setattr(expected_output, "__discriminant__", 5)
+    setattr(expected_output, "__name__", "SendTransferExecuteEgld")
     assert decoded_type == expected_output
 
 

--- a/multiversx_sdk/abi/enum_value.py
+++ b/multiversx_sdk/abi/enum_value.py
@@ -144,6 +144,11 @@ class EnumValue:
 
         setattr(obj, ENUM_DISCRIMINANT_FIELD_NAME, self.discriminant)
 
+        if self.names_to_discriminants is not None:
+            for name, discriminant in self.names_to_discriminants.items():
+                if discriminant == self.discriminant:
+                    setattr(obj, ENUM_NAME_FIELD_NAME, name)
+
         return obj
 
     def __eq__(self, other: Any) -> bool:

--- a/multiversx_sdk/abi/enum_value_test.py
+++ b/multiversx_sdk/abi/enum_value_test.py
@@ -97,7 +97,7 @@ def test_set_payload_and_get_payload_using_names():
     value = EnumValue(fields_provider=lambda discriminant: [], names_to_discriminants={"TypeB": 42})
     value.set_payload("TypeB")
     assert value.discriminant == 42
-    assert value.get_payload() == SimpleNamespace(__discriminant__=42)
+    assert value.get_payload() == SimpleNamespace(__discriminant__=42, __name__="TypeB")
 
     # With fields (from SimpleNamespace, object, dictionary or list)
     def provide_fields(discriminant: int) -> list[Field]:
@@ -124,7 +124,7 @@ def test_set_payload_and_get_payload_using_names():
     value.set_payload(SimpleNamespace(__name__="TypeA", a=1, b=2))
     assert value.discriminant == 41
     assert value.fields == [Field("a", U32Value(1)), Field("b", BigUIntValue(2))]
-    assert value.get_payload() == SimpleNamespace(__discriminant__=41, a=1, b=2)
+    assert value.get_payload() == SimpleNamespace(__discriminant__=41, __name__="TypeA", a=1, b=2)
     assert int(value.get_payload()) == 41
 
     class Payload:
@@ -137,19 +137,19 @@ def test_set_payload_and_get_payload_using_names():
     value.set_payload(Payload(3, 4))
     assert value.discriminant == 42
     assert value.fields == [Field("c", U32Value(3)), Field("d", BigUIntValue(4))]
-    assert value.get_payload() == SimpleNamespace(__discriminant__=42, c=3, d=4)
+    assert value.get_payload() == SimpleNamespace(__discriminant__=42, __name__="TypeB", c=3, d=4)
     assert int(value.get_payload()) == 42
 
     # Then, from dictionary
     value.set_payload({"__name__": "TypeC", "e": 5, "f": 6})
     assert value.discriminant == 43
     assert value.fields == [Field("e", U32Value(5)), Field("f", BigUIntValue(6))]
-    assert value.get_payload() == SimpleNamespace(__discriminant__=43, e=5, f=6)
+    assert value.get_payload() == SimpleNamespace(__discriminant__=43, __name__="TypeC", e=5, f=6)
     assert int(value.get_payload()) == 43
 
     # Finally, from list (first element is the name)
     value.set_payload(["TypeD", 7, 8])
     assert value.discriminant == 44
     assert value.fields == [Field("g", U32Value(7)), Field("h", BigUIntValue(8))]
-    assert value.get_payload() == SimpleNamespace(__discriminant__=44, g=7, h=8)
+    assert value.get_payload() == SimpleNamespace(__discriminant__=44, __name__="TypeD", g=7, h=8)
     assert int(value.get_payload()) == 44

--- a/multiversx_sdk/core/transaction_events_parser_test.py
+++ b/multiversx_sdk/core/transaction_events_parser_test.py
@@ -135,7 +135,7 @@ def test_parse_multisig_start_perform_action():
                     arguments=[bytes.fromhex("07")],
                 ),
                 "__discriminant__": 5,
-                "__name__": "SendTransferExecuteEgld"
+                "__name__": "SendTransferExecuteEgld",
             }
         ),
         signers=[
@@ -285,6 +285,7 @@ def test_multisig_start_perform_action():
                     }
                 ),
                 "__discriminant__": 5,
+                "__name__": "SendTransferExecuteEgld",
             },
         ),
         signers=[

--- a/multiversx_sdk/core/transaction_events_parser_test.py
+++ b/multiversx_sdk/core/transaction_events_parser_test.py
@@ -135,6 +135,7 @@ def test_parse_multisig_start_perform_action():
                     arguments=[bytes.fromhex("07")],
                 ),
                 "__discriminant__": 5,
+                "__name__": "SendTransferExecuteEgld"
             }
         ),
         signers=[


### PR DESCRIPTION
# Context

When a user do a query while providing an ABI and expectes an enum as a result, he will receive the discriminant of the variant of the Enum. This is not very user friendly as the variant are originally defined by name.

# Proposed Changes

When the `names_to_discriminants` dict is available in the `EnumValue` prototype, return also the name of the variant in the payload.

This allow to go from `{__discriminant__=43, e=5, f=6}` to `{__discriminant__=43, __name__="TypeC", e=5, f=6}`