### PR TITLE
Add eq and str for token

### DIFF
--- a/multiversx_sdk/core/tokens.py
+++ b/multiversx_sdk/core/tokens.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Any, Union
 
 from multiversx_sdk.abi.biguint_value import BigUIntValue
 from multiversx_sdk.abi.serializer import Serializer
@@ -14,6 +14,11 @@ class Token:
         self.identifier = identifier
         self.nonce = nonce
 
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, Token):
+            return False
+        return self.identifier == other.identifier and self.nonce == other.nonce
+
 
 class TokenTransfer:
     def __init__(self, token: Token, amount: int) -> None:
@@ -25,6 +30,11 @@ class TokenTransfer:
     def new_from_native_amount(amount: int) -> "TokenTransfer":
         native_token = Token(EGLD_IDENTIFIER_FOR_MULTI_ESDTNFT_TRANSFER)
         return TokenTransfer(native_token, amount)
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, TokenTransfer):
+            return False
+        return self.token == other.token and self.amount == other.amount
 
 
 class TokenIdentifierParts:

--- a/multiversx_sdk/core/tokens.py
+++ b/multiversx_sdk/core/tokens.py
@@ -19,6 +19,9 @@ class Token:
             return False
         return self.identifier == other.identifier and self.nonce == other.nonce
 
+    def __str__(self) -> str:
+        return TokenComputer().compute_extended_identifier(self)
+
 
 class TokenTransfer:
     def __init__(self, token: Token, amount: int) -> None:
@@ -35,6 +38,9 @@ class TokenTransfer:
         if not isinstance(other, TokenTransfer):
             return False
         return self.token == other.token and self.amount == other.amount
+
+    def __str__(self) -> str:
+        return f"{self.amount} {self.token}"
 
 
 class TokenIdentifierParts:

--- a/multiversx_sdk/core/tokens_test.py
+++ b/multiversx_sdk/core/tokens_test.py
@@ -167,3 +167,13 @@ def test_token_transfer_equality():
     assert TokenTransfer.new_from_native_amount(123456) == TokenTransfer.new_from_native_amount(123456)
     assert TokenTransfer(Token("WEGLD-abcdef"), 123456) == TokenTransfer(Token("WEGLD-abcdef"), 123456)
     assert TokenTransfer(Token("NFT-abcdef", 8), 123456) == TokenTransfer(Token("NFT-abcdef", 8), 123456)
+
+
+def test_token_str():
+    assert str(Token("NFT-123456", 777)) == "NFT-123456-0309"
+    assert str(Token("test-NFT-123456", 123)) == "test-NFT-123456-7b"
+
+
+def test_token_transfer_str():
+    assert str(TokenTransfer(Token("WEGLD-abcdef"), 123456)) == "123456 WEGLD-abcdef"
+    assert str(TokenTransfer(Token("NFT-abcdef", 8), 123456)) == "123456 NFT-abcdef-08"

--- a/multiversx_sdk/core/tokens_test.py
+++ b/multiversx_sdk/core/tokens_test.py
@@ -159,14 +159,37 @@ def test_token_transfer_from_native_amount():
 
 
 def test_token_equality():
+    assert Token("WEGLD-abcdef") == Token("WEGLD-abcdef")
     assert Token("NFT-123456", 777) == Token("NFT-123456", 777)
     assert Token("test-NFT-123456", 777) == Token("test-NFT-123456", 777)
+
+
+def test_token_inequality():
+    assert Token("WEGLD-abcdeh") != Token("WEGLD-abcdef")
+    assert Token("WEGLD-abcdef", 778) != Token("WEGLD-abcdef", 777)
+    assert Token("WEGLD-abcdeg", 777) != Token("WEGLD-abcdef", 777)
+    assert Token("test-NFT-123456", 775) != Token("test-NFT-123456", 777)
+    assert Token("test-NFT-123457", 777) != Token("test-NFT-123456", 777)
+    assert Token("test-NFZ-123456", 777) != Token("test-NFT-123456", 777)
+    assert Token("tesp-NFT-123456", 777) != Token("test-NFT-123456", 777)
+    assert Token("WEGLD-abcdef") != TokenTransfer(Token("WEGLD-abcdef"), 0)  # test with object of diff types
 
 
 def test_token_transfer_equality():
     assert TokenTransfer.new_from_native_amount(123456) == TokenTransfer.new_from_native_amount(123456)
     assert TokenTransfer(Token("WEGLD-abcdef"), 123456) == TokenTransfer(Token("WEGLD-abcdef"), 123456)
     assert TokenTransfer(Token("NFT-abcdef", 8), 123456) == TokenTransfer(Token("NFT-abcdef", 8), 123456)
+
+
+def test_token_transfer_inequality():
+    assert TokenTransfer.new_from_native_amount(123457) != TokenTransfer.new_from_native_amount(123456)
+    assert TokenTransfer(Token("WEGLD-abcdef"), 123457) != TokenTransfer(Token("WEGLD-abcdef"), 123456)
+    assert TokenTransfer(Token("WEGLD-abcdeg"), 123456) != TokenTransfer(Token("WEGLD-abcdef"), 123456)
+    assert TokenTransfer(Token("NFT-abcdef", 8), 123457) != TokenTransfer(Token("NFT-abcdef", 8), 123456)
+    assert TokenTransfer(Token("NFT-abcdef", 7), 123456) != TokenTransfer(Token("NFT-abcdef", 8), 123456)
+    assert TokenTransfer(Token("NFT-abcdeg", 8), 123456) != TokenTransfer(Token("NFT-abcdef", 8), 123456)
+    assert TokenTransfer(Token("NFT-abcdeh", 7), 123457) != TokenTransfer(Token("NFT-abcdef", 8), 123456)
+    assert TokenTransfer(Token("WEGLD-abcdef"), 0) != Token("WEGLD-abcdef")  # test with object of diff types
 
 
 def test_token_str():

--- a/multiversx_sdk/core/tokens_test.py
+++ b/multiversx_sdk/core/tokens_test.py
@@ -156,3 +156,14 @@ def test_token_transfer_from_native_amount():
     assert transfer.token.identifier == "EGLD-000000"
     assert transfer.token.nonce == 0
     assert transfer.amount == 1000000000000000000
+
+
+def test_token_equality():
+    assert Token("NFT-123456", 777) == Token("NFT-123456", 777)
+    assert Token("test-NFT-123456", 777) == Token("test-NFT-123456", 777)
+
+
+def test_token_transfer_equality():
+    assert TokenTransfer.new_from_native_amount(123456) == TokenTransfer.new_from_native_amount(123456)
+    assert TokenTransfer(Token("WEGLD-abcdef"), 123456) == TokenTransfer(Token("WEGLD-abcdef"), 123456)
+    assert TokenTransfer(Token("NFT-abcdef", 8), 123456) == TokenTransfer(Token("NFT-abcdef", 8), 123456)


### PR DESCRIPTION
# Context

Currently the classses `Token` and `TokenTransfer` cannot be compared

```python
>>>Token("NFT-123456", 777) == Token("NFT-123456", 777)
False
```
and they are displayed as object

```python
>>>print(Token("NFT-123456", 777))
<multiversx_sdk.core.tokens.Token object at 0x75c4c8349550>
```

# Proposed Changes

implement `__eq__` and `__str__` for `Token` and `TokenTransfer`