### PR TITLE
Set correct options for guarded transactions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.abspath(".."))
 project = "multiversx-sdk"
 copyright = "2024, MultiversX"
 author = "MultiversX"
-release = "1.3.1"
+release = "1.4.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/multiversx_sdk/account_management/account_controller.py
+++ b/multiversx_sdk/account_management/account_controller.py
@@ -43,6 +43,7 @@ class AccountController(BaseController):
         nonce: int,
         guardian_address: Address,
         service_id: str,
+        guardian: Optional[Address] = None,
         relayer: Optional[Address] = None,
         gas_limit: Optional[int] = None,
         gas_price: Optional[int] = None,
@@ -52,12 +53,13 @@ class AccountController(BaseController):
             guardian_address=guardian_address,
             service_id=service_id,
         )
-
+        transaction.guardian = guardian
         transaction.relayer = relayer
         transaction.nonce = nonce
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -77,6 +79,7 @@ class AccountController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -97,6 +100,7 @@ class AccountController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction

--- a/multiversx_sdk/core/base_controller.py
+++ b/multiversx_sdk/core/base_controller.py
@@ -10,7 +10,7 @@ from multiversx_sdk.core.transaction_computer import TransactionComputer
 
 
 class BaseController:
-    """This is the base class for all controllers. **Internal use only**."""
+    """This is the base class for all controllers. **Internal use only.**"""
 
     def _set_version_and_options_for_hash_signing(self, sender: IAccount, transaction: Transaction):
         """If the Account has the `use_hash_signing` flag set to `True`, this method will set the correct `version` and `options` properties of `Transaction`."""
@@ -39,3 +39,8 @@ class BaseController:
             transaction.gas_limit = gas_limit
         else:
             self._add_extra_gas_limit_if_required(transaction)
+
+    def _set_version_and_options_for_guardian(self, transaction: Transaction):
+        if transaction.guardian:
+            transaction_computer = TransactionComputer()
+            transaction_computer.apply_guardian(transaction, transaction.guardian)

--- a/multiversx_sdk/core/base_controller_test.py
+++ b/multiversx_sdk/core/base_controller_test.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+from multiversx_sdk.accounts.account import Account
+from multiversx_sdk.core.address import Address
+from multiversx_sdk.core.base_controller import BaseController
+from multiversx_sdk.core.transaction import Transaction
+
+
+class TestBaseController:
+    controller = BaseController()
+
+    def test_version_and_options_for_hash_signing(self):
+        testwallets = Path(__file__).parent.parent / "testutils" / "testwallets"
+        alice = Account.new_from_pem(testwallets / "alice.pem")
+        alice.use_hash_signing = True
+
+        transaction = Transaction(
+            sender=alice.address,
+            receiver=Address.new_from_bech32("erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx"),
+            gas_limit=50_000,
+            chain_id="D",
+            version=1,
+            options=0,
+        )
+
+        self.controller._set_version_and_options_for_hash_signing(sender=alice, transaction=transaction)  # type: ignore
+        assert transaction.version == 2
+        assert transaction.options == 1
+
+    def test_add_extra_gas_limit(self):
+        transaction = Transaction(
+            sender=Address.new_from_bech32("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"),
+            receiver=Address.new_from_bech32("erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx"),
+            gas_limit=50_000,
+            chain_id="D",
+            guardian=Address.new_from_bech32("erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8"),
+            relayer=Address.new_from_bech32("erd1kdl46yctawygtwg2k462307dmz2v55c605737dp3zkxh04sct7asqylhyv"),
+        )
+
+        self.controller._add_extra_gas_limit_if_required(transaction=transaction)  # type: ignore
+        assert transaction.gas_limit == 150_000
+
+    def test_set_version_and_options_for_guardian(self):
+        transaction = Transaction(
+            sender=Address.new_from_bech32("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"),
+            receiver=Address.new_from_bech32("erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx"),
+            gas_limit=50_000,
+            chain_id="D",
+            guardian=Address.new_from_bech32("erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8"),
+            version=1,
+            options=0,
+        )
+
+        self.controller._set_version_and_options_for_guardian(transaction=transaction)  # type: ignore
+        assert transaction.version == 2
+        assert transaction.options == 2

--- a/multiversx_sdk/delegation/delegation_controller.py
+++ b/multiversx_sdk/delegation/delegation_controller.py
@@ -63,6 +63,7 @@ class DelegationController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -103,6 +104,7 @@ class DelegationController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -130,6 +132,7 @@ class DelegationController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -157,6 +160,7 @@ class DelegationController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -184,6 +188,7 @@ class DelegationController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -211,6 +216,7 @@ class DelegationController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -240,6 +246,7 @@ class DelegationController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -267,6 +274,7 @@ class DelegationController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -294,6 +302,7 @@ class DelegationController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -318,6 +327,7 @@ class DelegationController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -342,6 +352,7 @@ class DelegationController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -366,6 +377,7 @@ class DelegationController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -390,6 +402,7 @@ class DelegationController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -421,6 +434,7 @@ class DelegationController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -448,6 +462,7 @@ class DelegationController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -479,6 +494,7 @@ class DelegationController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -510,6 +526,7 @@ class DelegationController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -544,6 +561,7 @@ class DelegationController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -575,6 +593,7 @@ class DelegationController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction

--- a/multiversx_sdk/relayed/relayed_controller.py
+++ b/multiversx_sdk/relayed/relayed_controller.py
@@ -32,6 +32,7 @@ class RelayedController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._add_extra_gas_limit_if_required(transaction)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -53,6 +54,7 @@ class RelayedController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._add_extra_gas_limit_if_required(transaction)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction

--- a/multiversx_sdk/smart_contracts/smart_contract_controller.py
+++ b/multiversx_sdk/smart_contracts/smart_contract_controller.py
@@ -90,6 +90,7 @@ class SmartContractController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -137,6 +138,7 @@ class SmartContractController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -171,6 +173,7 @@ class SmartContractController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction

--- a/multiversx_sdk/token_management/token_management_controller.py
+++ b/multiversx_sdk/token_management/token_management_controller.py
@@ -92,6 +92,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -140,6 +141,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -190,6 +192,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -240,6 +243,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -278,6 +282,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -313,6 +318,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -344,6 +350,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -384,6 +391,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -428,6 +436,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -463,6 +472,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -507,6 +517,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -541,6 +552,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -585,6 +597,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -622,6 +635,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -678,6 +692,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -715,6 +730,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -746,6 +762,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -777,6 +794,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -809,6 +827,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -841,6 +860,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -873,6 +893,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -907,6 +928,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -941,6 +963,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -977,6 +1000,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -1013,6 +1037,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -1049,6 +1074,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -1085,6 +1111,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -1121,6 +1148,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -1153,6 +1181,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -1197,6 +1226,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -1241,6 +1271,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -1274,6 +1305,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -1310,6 +1342,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -1344,6 +1377,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -1386,6 +1420,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -1424,6 +1459,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -1453,6 +1489,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -1482,6 +1519,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -1507,6 +1545,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -1532,6 +1571,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -1556,6 +1596,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -1585,6 +1626,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -1614,6 +1656,7 @@ class TokenManagementController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction

--- a/multiversx_sdk/transfers/transfers_controller.py
+++ b/multiversx_sdk/transfers/transfers_controller.py
@@ -38,6 +38,7 @@ class TransfersController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -63,6 +64,7 @@ class TransfersController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -94,6 +96,7 @@ class TransfersController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction

--- a/multiversx_sdk/validators/validators_controller.py
+++ b/multiversx_sdk/validators/validators_controller.py
@@ -42,6 +42,7 @@ class ValidatorsController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -67,6 +68,7 @@ class ValidatorsController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -92,6 +94,7 @@ class ValidatorsController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -119,6 +122,7 @@ class ValidatorsController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -144,6 +148,7 @@ class ValidatorsController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -169,6 +174,7 @@ class ValidatorsController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -192,6 +198,7 @@ class ValidatorsController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -217,6 +224,7 @@ class ValidatorsController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -242,6 +250,7 @@ class ValidatorsController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -267,6 +276,7 @@ class ValidatorsController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -292,6 +302,7 @@ class ValidatorsController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -315,6 +326,7 @@ class ValidatorsController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction
@@ -340,6 +352,7 @@ class ValidatorsController(BaseController):
 
         self._set_version_and_options_for_hash_signing(sender, transaction)
         self._set_transaction_gas_options(transaction, gas_limit, gas_price)
+        self._set_version_and_options_for_guardian(transaction)
         transaction.signature = sender.sign_transaction(transaction)
 
         return transaction

--- a/multiversx_sdk/validators/validators_controller_test.py
+++ b/multiversx_sdk/validators/validators_controller_test.py
@@ -99,7 +99,7 @@ class TestValidatorsController:
         assert transaction.gas_limit == 11129500
         assert transaction.chain_id == "localnet"
         assert transaction.version == 2
-        assert transaction.options == 0
+        assert transaction.options == 2
         assert transaction.guardian == Address.new_from_bech32(
             "erd1cqqxak4wun7508e0yj9ng843r6hv4mzd0hhpjpsejkpn9wa9yq8sj7u2u5"
         )

--- a/multiversx_sdk/validators/validators_controller_test.py
+++ b/multiversx_sdk/validators/validators_controller_test.py
@@ -108,7 +108,7 @@ class TestValidatorsController:
         )
         assert (
             transaction.signature.hex()
-            == "b12d607a8c52c2cdfc8f239274a45ead211fb12e79fb6c36866d9bae74c6a50b52ebf1c2eb57e2a89dc29fd8da8f6d7ff70c96a0267dd7e2f050d5b61f439100"
+            == "0fd033bb889ea539f66e2e7e194cead88c76c98638c7734ea2d63d30ac9889b90bd248b9266f98f256992ffed48fbd80b0dc5196287f671898f18159bdbb2505"
         )
         assert (
             transaction.data.decode()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "multiversx-sdk"
-version = "1.3.1"
+version = "1.4.0"
 authors = [
   { name="MultiversX" },
 ]


### PR DESCRIPTION
The `transactions options` were not properly set when creating guarded transactions using the controllers.

Also, added a new guardian argument for `create_transaction_for_setting_guardian()`.