### PR TITLE
Fix duplication of user agent

### DIFF
--- a/multiversx_sdk/network_providers/api_network_provider.py
+++ b/multiversx_sdk/network_providers/api_network_provider.py
@@ -1,4 +1,5 @@
 import urllib.parse
+from copy import deepcopy
 from typing import Any, Callable, Optional, Union, cast
 
 import requests
@@ -76,7 +77,7 @@ class ApiNetworkProvider(INetworkProvider):
         self.url = url
         self.address_hrp = address_hrp or LibraryConfig.default_address_hrp
         self.backing_proxy = ProxyNetworkProvider(url, self.address_hrp)
-        self.config = config if config is not None else NetworkProviderConfig()
+        self.config = deepcopy(config) if config is not None else NetworkProviderConfig()
 
         self.user_agent_prefix = f"{BASE_USER_AGENT}/api"
         extend_user_agent(self.user_agent_prefix, self.config)

--- a/multiversx_sdk/network_providers/api_network_provider_test.py
+++ b/multiversx_sdk/network_providers/api_network_provider_test.py
@@ -443,7 +443,7 @@ class TestApi:
         config = NetworkProviderConfig(client_name="test-client")
         api = ApiNetworkProvider(url="https://devnet-api.multiversx.com", config=config)
 
-        response = requests.get(api.url + "/network/config", **config.requests_options)
+        response = requests.get(api.url + "/network/config", **api.config.requests_options)
         headers = response.request.headers
         assert headers.get("User-Agent") == "multiversx-sdk-py/api/test-client"
 

--- a/multiversx_sdk/network_providers/api_network_provider_test.py
+++ b/multiversx_sdk/network_providers/api_network_provider_test.py
@@ -446,3 +446,24 @@ class TestApi:
         response = requests.get(api.url + "/network/config", **config.requests_options)
         headers = response.request.headers
         assert headers.get("User-Agent") == "multiversx-sdk-py/api/test-client"
+
+    def test_query_contract_without_return_data(self):
+        query = SmartContractQuery(
+            contract=Address.new_from_bech32("erd1qqqqqqqqqqqqqpgqf738mcf8f08kuwhn8dvtka5veyad2fqwu00sqnjgln"),
+            function="getAllProposers",
+            arguments=[],
+        )
+        response = self.api.query_contract(query)
+        assert response.return_data_parts == []
+
+    def test_same_config_with_multiple_network_providers(self):
+        config = NetworkProviderConfig(client_name="test-client")
+        api = ApiNetworkProvider(url="https://devnet-api.multiversx.com", config=config)
+
+        response = requests.get(api.url + "/network/config", **api.config.requests_options)
+        headers = response.request.headers
+        assert headers.get("User-Agent") == "multiversx-sdk-py/api/test-client"
+
+        # create new network provider with old config, we don't alter the config anymore
+        api = ApiNetworkProvider(url="https://devnet-api.multiversx.com", config=config)
+        assert api.config.requests_options.get("headers", {}).get("User-Agent") == "multiversx-sdk-py/api/test-client"

--- a/multiversx_sdk/network_providers/proxy_network_provider.py
+++ b/multiversx_sdk/network_providers/proxy_network_provider.py
@@ -1,5 +1,6 @@
 import urllib.parse
 from concurrent.futures import ThreadPoolExecutor, TimeoutError
+from copy import deepcopy
 from threading import Thread
 from typing import Any, Callable, Optional, Union
 
@@ -78,7 +79,7 @@ class ProxyNetworkProvider(INetworkProvider):
     ) -> None:
         self.url = url
         self.address_hrp = address_hrp or LibraryConfig.default_address_hrp
-        self.config = config if config is not None else NetworkProviderConfig()
+        self.config = deepcopy(config) if config is not None else NetworkProviderConfig()
 
         self.user_agent_prefix = f"{BASE_USER_AGENT}/proxy"
         extend_user_agent(self.user_agent_prefix, self.config)

--- a/multiversx_sdk/network_providers/proxy_network_provider_test.py
+++ b/multiversx_sdk/network_providers/proxy_network_provider_test.py
@@ -430,7 +430,7 @@ class TestProxy:
         config = NetworkProviderConfig(client_name="test-client")
         proxy = ProxyNetworkProvider(url="https://devnet-gateway.multiversx.com", config=config)
 
-        response = requests.get(proxy.url + "/network/config", **config.requests_options)
+        response = requests.get(proxy.url + "/network/config", **proxy.config.requests_options)
         headers = response.request.headers
         assert headers.get("User-Agent") == "multiversx-sdk-py/proxy/test-client"
 

--- a/multiversx_sdk/network_providers/proxy_network_provider_test.py
+++ b/multiversx_sdk/network_providers/proxy_network_provider_test.py
@@ -406,6 +406,15 @@ class TestProxy:
         miniblocks = block.get("miniBlocks", [])
         assert miniblocks[0]["transactions"]
 
+    def test_query_contract_without_return_data(self):
+        query = SmartContractQuery(
+            contract=Address.new_from_bech32("erd1qqqqqqqqqqqqqpgqf738mcf8f08kuwhn8dvtka5veyad2fqwu00sqnjgln"),
+            function="getAllProposers",
+            arguments=[],
+        )
+        response = self.proxy.query_contract(query)
+        assert response.return_data_parts == []
+
     def test_user_agent(self):
         # using config without user agent
         config = NetworkProviderConfig()
@@ -424,3 +433,17 @@ class TestProxy:
         response = requests.get(proxy.url + "/network/config", **config.requests_options)
         headers = response.request.headers
         assert headers.get("User-Agent") == "multiversx-sdk-py/proxy/test-client"
+
+    def test_same_config_with_multiple_network_providers(self):
+        config = NetworkProviderConfig(client_name="test-client")
+        proxy = ProxyNetworkProvider(url="https://devnet-gateway.multiversx.com", config=config)
+
+        response = requests.get(proxy.url + "/network/config", **proxy.config.requests_options)
+        headers = response.request.headers
+        assert headers.get("User-Agent") == "multiversx-sdk-py/proxy/test-client"
+
+        # create new network provider with old config, we don't alter the config anymore
+        proxy = ProxyNetworkProvider(url="https://devnet-gateway.multiversx.com", config=config)
+        assert (
+            proxy.config.requests_options.get("headers", {}).get("User-Agent") == "multiversx-sdk-py/proxy/test-client"
+        )


### PR DESCRIPTION
If the same `NetworkProviderConfig` was used to instantiate multiple network providers, `User-Agent` used to duplicate for each network provider. Now, we don't alter the config anymore.