### PR TITLE
Grant write permission for docs workflow

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   build:


### PR DESCRIPTION
The workflow pushes to the `gh-pages` branch, thus it needs write permission.