### PR TITLE
Estimate gas limit on controllers & allow ESDT transfer and data

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.abspath(".."))
 project = "multiversx-sdk"
 copyright = "2025, MultiversX"
 author = "MultiversX"
-release = "2.1.0"
+release = "2.3.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/multiversx_sdk/account_management/account_controller.py
+++ b/multiversx_sdk/account_management/account_controller.py
@@ -10,11 +10,9 @@ from multiversx_sdk.core.transactions_factory_config import TransactionsFactoryC
 
 
 class AccountController(BaseController):
-    def __init__(self, chain_id: str, gasLimitEstimator: Optional[IGasLimitEstimator] = None) -> None:
-        self.factory = AccountTransactionsFactory(
-            config=TransactionsFactoryConfig(chain_id),
-            gas_limit_estimator=gasLimitEstimator,
-        )
+    def __init__(self, chain_id: str, gas_limit_estimator: Optional[IGasLimitEstimator] = None) -> None:
+        super().__init__(gas_limit_estimator=gas_limit_estimator)
+        self.factory = AccountTransactionsFactory(config=TransactionsFactoryConfig(chain_id))
 
     def create_transaction_for_saving_key_value(
         self,

--- a/multiversx_sdk/delegation/delegation_controller.py
+++ b/multiversx_sdk/delegation/delegation_controller.py
@@ -39,8 +39,9 @@ class DelegationController(BaseController):
         network_provider: INetworkProvider,
         gas_limit_estimator: Optional[IGasLimitEstimator] = None,
     ) -> None:
+        super().__init__(gas_limit_estimator=gas_limit_estimator)
         self.network_provider = network_provider
-        self.factory = DelegationTransactionsFactory(TransactionsFactoryConfig(chain_id), gas_limit_estimator)
+        self.factory = DelegationTransactionsFactory(config=TransactionsFactoryConfig(chain_id))
         self.parser = DelegationTransactionsOutcomeParser()
 
     def create_transaction_for_new_delegation_contract(

--- a/multiversx_sdk/governance/governance_controller.py
+++ b/multiversx_sdk/governance/governance_controller.py
@@ -57,7 +57,8 @@ class GovernanceController(BaseController):
         address_hrp: Optional[str] = None,
         gas_limit_estimator: Optional[IGasLimitEstimator] = None,
     ) -> None:
-        self._factory = GovernanceTransactionsFactory(TransactionsFactoryConfig(chain_id), gas_limit_estimator)
+        super().__init__(gas_limit_estimator=gas_limit_estimator)
+        self._factory = GovernanceTransactionsFactory(config=TransactionsFactoryConfig(chain_id))
         self._network_provider = network_provider
         self._governance_contract = Address.new_from_hex(GOVERNANCE_SMART_CONTRACT_ADDRESS_HEX)
         self._sc_controller = SmartContractController(chain_id, network_provider)

--- a/multiversx_sdk/multisig/multisig_controller.py
+++ b/multiversx_sdk/multisig/multisig_controller.py
@@ -65,11 +65,11 @@ class MultisigController(BaseController):
         address_hrp: Optional[str] = None,
         gas_limit_estimator: Optional[IGasLimitEstimator] = None,
     ) -> None:
+        super().__init__(gas_limit_estimator=gas_limit_estimator)
         self._network_provider = network_provider
         self._factory = MultisigTransactionsFactory(
             config=TransactionsFactoryConfig(chain_id),
             abi=abi,
-            gas_limit_estimator=gas_limit_estimator,
         )
         self._parser = MultisigTransactionsOutcomeParser(abi=abi)
         self._smart_contract_controller = SmartContractController(

--- a/multiversx_sdk/smart_contracts/smart_contract_controller.py
+++ b/multiversx_sdk/smart_contracts/smart_contract_controller.py
@@ -51,11 +51,11 @@ class SmartContractController(BaseController):
         abi: Optional[Abi] = None,
         gas_limit_estimator: Optional[IGasLimitEstimator] = None,
     ) -> None:
+        super().__init__(gas_limit_estimator=gas_limit_estimator)
         self.abi = abi
         self.factory = SmartContractTransactionsFactory(
-            TransactionsFactoryConfig(chain_id),
+            config=TransactionsFactoryConfig(chain_id),
             abi=self.abi,
-            gas_limit_estimator=gas_limit_estimator,
         )
         self.parser = SmartContractTransactionsOutcomeParser(abi=self.abi)
         self.network_provider = network_provider

--- a/multiversx_sdk/token_management/token_management_controller.py
+++ b/multiversx_sdk/token_management/token_management_controller.py
@@ -54,7 +54,8 @@ class TokenManagementController(BaseController):
         network_provider: INetworkProvider,
         gas_limit_estimator: Optional[IGasLimitEstimator] = None,
     ) -> None:
-        self.factory = TokenManagementTransactionsFactory(TransactionsFactoryConfig(chain_id), gas_limit_estimator)
+        super().__init__(gas_limit_estimator=gas_limit_estimator)
+        self.factory = TokenManagementTransactionsFactory(config=TransactionsFactoryConfig(chain_id))
         self.network_provider = network_provider
         self.parser = TokenManagementTransactionsOutcomeParser()
 

--- a/multiversx_sdk/transfers/transfers_controller.py
+++ b/multiversx_sdk/transfers/transfers_controller.py
@@ -15,7 +15,8 @@ class TransfersController(BaseController):
         chain_id: str,
         gas_limit_estimator: Optional[IGasLimitEstimator] = None,
     ) -> None:
-        self.factory = TransferTransactionsFactory(TransactionsFactoryConfig(chain_id), gas_limit_estimator)
+        super().__init__(gas_limit_estimator=gas_limit_estimator)
+        self.factory = TransferTransactionsFactory(config=TransactionsFactoryConfig(chain_id))
 
     def create_transaction_for_native_token_transfer(
         self,

--- a/multiversx_sdk/transfers/transfers_controller_test.py
+++ b/multiversx_sdk/transfers/transfers_controller_test.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+from multiversx_sdk.accounts.account import Account
+from multiversx_sdk.core.address import Address
+from multiversx_sdk.core.tokens import Token, TokenTransfer
+from multiversx_sdk.entrypoints.entrypoints import DevnetEntrypoint
+from multiversx_sdk.wallet.user_keys import UserSecretKey
+
+
+class TestTransfersController:
+    sender = Account(UserSecretKey(bytes.fromhex("bdf3c95c4b0bcbacd828b148231a10c25f93286befe92077b5d096055fb4e96a")))
+    mike = Address.new_from_bech32("erd1uv40ahysflse896x4ktnh6ecx43u7cmy9wnxnvcyp7deg299a4sq6vaywa")
+    grace = Account.new_from_pem(Path(__file__).parent.parent / "testutils" / "testwallets" / "grace.pem")
+    usdc = "USDC-350c4e"
+
+    entrypoint = DevnetEntrypoint(kind="proxy", with_gas_limit_estimator=True)
+    proxy = entrypoint.create_network_provider()
+    controller = entrypoint.create_transfers_controller()
+
+    def test_send_relayed_with_no_native_balance(self):
+        self.sender.nonce = self.entrypoint.recall_account_nonce(self.sender.address)
+        transaction = self.controller.create_transaction_for_transfer(
+            sender=self.sender,
+            nonce=self.sender.get_nonce_then_increment(),
+            receiver=self.mike,
+            token_transfers=[TokenTransfer(Token(self.usdc), 7)],
+            data="hello".encode(),
+            relayer=self.grace.address,
+        )
+        transaction.relayer_signature = self.grace.sign_transaction(transaction)
+
+        assert transaction.sender.to_bech32() == "erd1th3kjm4yjd25lwewe4m5akuqsappqdml8jxuneasnavj7752veysa2sylq"
+        assert transaction.receiver.to_bech32() == self.mike.to_bech32()
+        assert transaction.chain_id == "D"
+        assert transaction.gas_limit == 373_501
+        assert transaction.data.decode() == "ESDTTransfer@555344432d333530633465@07@68656c6c6f"

--- a/multiversx_sdk/validators/validators_controller.py
+++ b/multiversx_sdk/validators/validators_controller.py
@@ -15,7 +15,8 @@ from multiversx_sdk.wallet.validator_keys import ValidatorPublicKey
 
 class ValidatorsController(BaseController):
     def __init__(self, chain_id: str, gas_limit_estimator: Optional[IGasLimitEstimator] = None) -> None:
-        self.factory = ValidatorsTransactionsFactory(TransactionsFactoryConfig(chain_id), gas_limit_estimator)
+        super().__init__(gas_limit_estimator=gas_limit_estimator)
+        self.factory = ValidatorsTransactionsFactory(config=TransactionsFactoryConfig(chain_id))
 
     def create_transaction_for_staking(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "multiversx-sdk"
-version = "2.2.0"
+version = "2.3.0"
 authors = [
   { name="MultiversX" },
 ]


### PR DESCRIPTION
**Possible Breaking Change**

For the **AccountController** the parameter `gasLimitEstimator` was renamed to `gas_limit_estimator`.

For the `TransferController` and `TransferTransactionsFactory` the limitation of not sending arbitrary data together with ESDT transfer has been removed.